### PR TITLE
feat: add playful theme and style guide

### DIFF
--- a/app/example/page.tsx
+++ b/app/example/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+
+const games = [
+  { name: 'Duck Duck Goose', age: '5+', players: '5-20', time: '10m', space: 'outdoor' },
+  { name: 'Charades', age: '8+', players: '4-8', time: '15m', space: 'indoor' },
+  { name: 'Musical Chairs', age: '6+', players: '6-12', time: '10m', space: 'indoor' },
+];
+
+export default function ExamplePage() {
+  const [query, setQuery] = useState('');
+  const filtered = games.filter(g => g.name.toLowerCase().includes(query.toLowerCase()));
+
+  return (
+    <div className="space-y-12">
+      <section className="text-center space-y-4">
+        <h1>Find the perfect game for any group</h1>
+        <p className="text-lg text-neutral-600 dark:text-neutral-300">
+          Search and filter games by age, players, time and space.
+        </p>
+        <div className="flex justify-center gap-4">
+          <Button>Get Started</Button>
+          <Button variant="secondary">Random Game</Button>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center gap-4">
+          <Input
+            placeholder="Search games..."
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            className="w-full sm:w-64"
+          />
+          <div className="flex flex-wrap gap-2">
+            {['Indoor', 'Outdoor', 'No Prep'].map(tag => (
+              <Badge key={tag} variant="secondary" className="cursor-pointer">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        {filtered.length ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filtered.map(game => (
+              <Card key={game.name} className="shadow-subtle">
+                <CardHeader>
+                  <CardTitle className="font-heading text-xl">{game.name}</CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-wrap gap-2">
+                  <Badge>{game.age} yrs</Badge>
+                  <Badge>{game.players} players</Badge>
+                  <Badge>{game.time}</Badge>
+                  <Badge>{game.space}</Badge>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <Card className="p-8 text-center">
+            <p className="text-neutral-600 dark:text-neutral-300">No games match your search.</p>
+          </Card>
+        )}
+      </section>
+
+      {filtered.length > 0 && (
+        <section className="space-y-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Game</TableHead>
+                <TableHead>Age</TableHead>
+                <TableHead>Players</TableHead>
+                <TableHead>Time</TableHead>
+                <TableHead>Space</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.map(game => (
+                <TableRow key={game.name}>
+                  <TableCell className="font-medium">{game.name}</TableCell>
+                  <TableCell>{game.age}</TableCell>
+                  <TableCell>{game.players}</TableCell>
+                  <TableCell>{game.time}</TableCell>
+                  <TableCell>{game.space}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <div className="flex justify-end gap-2">
+            <Button size="sm" variant="secondary">Previous</Button>
+            <Button size="sm">Next</Button>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,199 +1,55 @@
 @tailwind base;
-
 @plugin "tailwindcss-animate";
-
-@custom-variant dark (&:is(.dark *));
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 10% 3.9%;
-    --radius: 0.5rem;
+    --color-primary: #2E7D32;
+    --color-secondary: #1976D2;
+    --color-accent: #FFB300;
+    --color-neutral-50: #F8FAFC;
+    --color-neutral-100: #E5E9EC;
+    --color-neutral-200: #CBD2D9;
+    --color-neutral-300: #A1A9B1;
+    --color-neutral-400: #7A828B;
+    --color-neutral-500: #555D64;
+    --color-neutral-600: #3B4248;
+    --color-neutral-700: #23292E;
+    --color-neutral-800: #14191D;
+    --color-neutral-900: #0B0F12;
+
+    --background: var(--color-neutral-50);
+    --foreground: var(--color-neutral-900);
+    --radius: 16px;
+    --focus-ring: oklch(0.7 0.2 150);
   }
 
   .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 0 0% 98%;
+    --background: var(--color-neutral-900);
+    --foreground: var(--color-neutral-50);
   }
-}
 
-@layer base {
   * {
-    border-color: hsl(var(--border));
+    border-color: var(--color-neutral-200);
   }
+
   body {
-    background-color: hsl(var(--background));
-    color: hsl(var(--foreground));
+    @apply bg-[var(--background)] text-[var(--foreground)] font-sans text-[16px] leading-[26px];
+  }
+
+  h1 {
+    @apply font-heading text-[40px] leading-[44px] font-bold;
+  }
+
+  *:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
   }
 }
 
-/* Print Styles */
-@media print {
-  body {
-    font-size: 10pt;
-    -webkit-print-color-adjust: exact;
-    print-color-adjust: exact;
-  }
-  header, footer, [data-no-print] {
-    display: none !important;
-  }
-  main {
-    padding: 0 !important;
-    margin: 0 !important;
-  }
-  .page-break {
-    page-break-before: always;
-  }
-}
-
-@theme inline {
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
-}
-
-:root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-}
-
-@layer base {
+@media (prefers-reduced-motion: reduce) {
   * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
+    @apply !transition-none !animate-none;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,13 @@
 // app/layout.tsx
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
+import { Inter, Outfit } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Header } from '@/components/header';
 import { Toaster } from "@/components/ui/sonner"; // <-- Import the new Toaster
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
+const outfit = Outfit({ subsets: ['latin'], variable: '--font-outfit' });
 
 export const metadata: Metadata = {
   // ... metadata
@@ -18,7 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         {/* ... head elements */}
       </head>
-      <body className={inter.className}>
+      <body className={`${inter.variable} ${outfit.variable}`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <Header />
           <main className="container mx-auto px-4 py-8">{children}</main>

--- a/app/style-guide/page.tsx
+++ b/app/style-guide/page.tsx
@@ -1,0 +1,34 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+export default function StyleGuidePage() {
+  return (
+    <div className="space-y-8">
+      <h1>Style Guide</h1>
+      <Card className="shadow-subtle">
+        <CardHeader>
+          <CardTitle className="font-heading text-2xl">Do</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="list-disc pl-6 space-y-2">
+            <li>Use 8px spacing increments.</li>
+            <li>Keep layouts bright, clean and welcoming.</li>
+            <li>Write in a friendly, trustworthy tone.</li>
+            <li>Ensure text maintains AA contrast or better.</li>
+          </ul>
+        </CardContent>
+      </Card>
+      <Card className="shadow-subtle">
+        <CardHeader>
+          <CardTitle className="font-heading text-2xl">Don’t</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="list-disc pl-6 space-y-2 text-red-700 dark:text-red-400">
+            <li>Avoid heavy neon hues or dark, busy backgrounds.</li>
+            <li>Don’t rely solely on motion; provide reduced-motion alternatives.</li>
+            <li>Skip tiny touch targets or low contrast text.</li>
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,0 +1,27 @@
+export const tokens = {
+  colors: {
+    primary: '#2E7D32',
+    secondary: '#1976D2',
+    accent: '#FFB300',
+    neutral: {
+      50: '#F8FAFC',
+      100: '#E5E9EC',
+      200: '#CBD2D9',
+      300: '#A1A9B1',
+      400: '#7A828B',
+      500: '#555D64',
+      600: '#3B4248',
+      700: '#23292E',
+      800: '#14191D',
+      900: '#0B0F12',
+    },
+  },
+  fonts: {
+    heading: 'Outfit',
+    body: 'Inter',
+  },
+  radius: '16px',
+  focus: 'oklch(0.7 0.2 150)',
+};
+
+export type Tokens = typeof tokens;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 // tailwind.config.ts
 import type { Config } from 'tailwindcss';
+import tailwindcssAnimate from 'tailwindcss-animate';
 
 const config = {
   darkMode: "class",
@@ -19,10 +20,44 @@ const config = {
       },
     },
     extend: {
-      // ... extend your theme if needed
+      colors: {
+        primary: 'var(--color-primary)',
+        secondary: 'var(--color-secondary)',
+        accent: 'var(--color-accent)',
+        neutral: {
+          50: 'var(--color-neutral-50)',
+          100: 'var(--color-neutral-100)',
+          200: 'var(--color-neutral-200)',
+          300: 'var(--color-neutral-300)',
+          400: 'var(--color-neutral-400)',
+          500: 'var(--color-neutral-500)',
+          600: 'var(--color-neutral-600)',
+          700: 'var(--color-neutral-700)',
+          800: 'var(--color-neutral-800)',
+          900: 'var(--color-neutral-900)',
+        },
+      },
+      fontFamily: {
+        sans: ['var(--font-inter)', 'sans-serif'],
+        heading: ['var(--font-outfit)', 'sans-serif'],
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 4px)',
+        sm: 'calc(var(--radius) - 8px)',
+      },
+      boxShadow: {
+        subtle: '0 1px 2px rgb(0 0 0 / 0.05)',
+      },
+      transitionDuration: {
+        DEFAULT: '150ms',
+      },
+      transitionTimingFunction: {
+        DEFAULT: 'ease-in-out',
+      },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;
 
 export default config;


### PR DESCRIPTION
## Summary
- define design tokens for playful Itsallfunandgames theme
- extend Tailwind with theme fonts, colors, radius and motion
- add CSS variables, example showcase page and style guide

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` & `Outfit` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b16fdbd8f883218b40b7177bfa0740