### PR TITLE
feat: style homepage and add facet filters

### DIFF
--- a/app/game-client.tsx
+++ b/app/game-client.tsx
@@ -4,13 +4,12 @@
 
 import { Game } from '@/lib/types';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
-import { useEffect, useState, useMemo, useRef, useCallback } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { useDebounce } from 'use-debounce';
 import Fuse from 'fuse.js';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Slider } from '@/components/ui/slider';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import Link from 'next/link';
@@ -35,7 +34,12 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
     sort: searchParams.get('sort') || 'name_asc',
     age: searchParams.get('age')?.split(',').map(Number) || [0, 99],
     players: searchParams.get('players')?.split(',').map(Number) || [1, 99],
-    // ... other facets
+    category: searchParams.get('category') || '',
+    tags: searchParams.get('tags') || '',
+    traditionality: searchParams.get('traditionality') || '',
+    prepLevel: searchParams.get('prepLevel') || '',
+    skillsDeveloped: searchParams.get('skillsDeveloped') || '',
+    regionalPopularity: searchParams.get('regionalPopularity') || '',
   });
 
   const [debouncedQuery] = useDebounce(filters.query, 300);
@@ -49,11 +53,26 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
       const fuse = new Fuse(allGames, fuseOptions);
       result = fuse.search(debouncedQuery).map(res => res.item);
     }
-    
-    // 2. Facet and Range filtering
-    // ... implement logic for age, players, category, etc.
-    // This part can get complex; for now, we'll just sort
-    
+
+    // 2. Facet filtering
+    result = result.filter(game => {
+      if (filters.category && game.category !== filters.category) return false;
+      if (filters.tags && !(game.tags || []).includes(filters.tags)) return false;
+      if (filters.traditionality && game.traditionality !== filters.traditionality) return false;
+      if (filters.prepLevel && game.prepLevel !== filters.prepLevel) return false;
+      if (
+        filters.skillsDeveloped &&
+        !(game.skillsDeveloped || []).includes(filters.skillsDeveloped)
+      )
+        return false;
+      if (
+        filters.regionalPopularity &&
+        !(game.regionalPopularity || []).includes(filters.regionalPopularity)
+      )
+        return false;
+      return true;
+    });
+
     // 3. Sorting
     result.sort((a, b) => {
         if (filters.sort === 'name_asc') return a.name.localeCompare(b.name);
@@ -63,13 +82,19 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
     });
 
     return result;
-  }, [allGames, debouncedQuery, filters.sort /*, other filters */]);
+  }, [allGames, debouncedQuery, filters]);
 
   // Effect to update URL when filters change
   useEffect(() => {
     const params = new URLSearchParams();
     if (filters.query) params.set('q', filters.query);
     if (filters.sort !== 'name_asc') params.set('sort', filters.sort);
+    if (filters.category) params.set('category', filters.category);
+    if (filters.tags) params.set('tags', filters.tags);
+    if (filters.traditionality) params.set('traditionality', filters.traditionality);
+    if (filters.prepLevel) params.set('prepLevel', filters.prepLevel);
+    if (filters.skillsDeveloped) params.set('skillsDeveloped', filters.skillsDeveloped);
+    if (filters.regionalPopularity) params.set('regionalPopularity', filters.regionalPopularity);
     // ... set other params
     router.replace(`${pathname}?${params.toString()}`);
   }, [filters, pathname, router]);
@@ -84,59 +109,161 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
   });
 
   return (
-    <div className="grid grid-cols-1 gap-8 md:grid-cols-4">
-      {/* Filters Sidebar */}
-      <aside className="md:col-span-1">
-        <h3 className="text-lg font-semibold">Filters</h3>
-        <div className="space-y-4 mt-4">
-            <Input 
-                placeholder="Search by name..."
-                value={filters.query}
-                onChange={(e) => setFilters(f => ({...f, query: e.target.value}))}
-            />
-            {/* ... Add other filter controls like Select, Slider etc. */}
-        </div>
-      </aside>
-
-      {/* Game List */}
-      <div className="md:col-span-3">
-        <div ref={parentRef} className="h-[80vh] overflow-y-auto">
-          <div style={{ height: `${rowVirtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}>
-            {rowVirtualizer.getVirtualItems().map(virtualItem => {
-              const game = filteredGames[virtualItem.index];
-              return (
-                <div
-                  key={game.id}
-                  style={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    width: '100%',
-                    height: `${virtualItem.size}px`,
-                    transform: `translateY(${virtualItem.start}px)`,
-                  }}
-                  className="p-2"
-                >
-                  <Card>
-                    <CardHeader>
-                        <Link href={`/game/${game.id}`}>
-                            <CardTitle>{game.name}</CardTitle>
-                        </Link>
-                    </CardHeader>
-                    <CardContent>
-                      <p className="text-sm text-muted-foreground line-clamp-2">{game.description}</p>
-                      <div className="mt-2">
-                        {game.tags.slice(0, 3).map(tag => <Badge key={tag} variant="secondary" className="mr-1">{tag}</Badge>)}
-                      </div>
-                    </CardContent>
-                  </Card>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-        {filteredGames.length === 0 && <p className="text-center text-muted-foreground">No games found.</p>}
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-4">
+        <Input
+          placeholder="Search by name..."
+          value={filters.query}
+          onChange={(e) => setFilters(f => ({ ...f, query: e.target.value }))}
+          className="w-full sm:max-w-xs"
+        />
+        <Select
+          value={filters.category}
+          onValueChange={value => setFilters(f => ({ ...f, category: value }))}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Category" />
+          </SelectTrigger>
+          <SelectContent>
+            {facets.category.map(cat => (
+              <SelectItem key={cat} value={cat}>
+                {cat}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={filters.tags}
+          onValueChange={value => setFilters(f => ({ ...f, tags: value }))}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Tag" />
+          </SelectTrigger>
+          <SelectContent>
+            {facets.tags.map(tag => (
+              <SelectItem key={tag} value={tag}>
+                {tag}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={filters.traditionality}
+          onValueChange={value => setFilters(f => ({ ...f, traditionality: value }))}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Traditionality" />
+          </SelectTrigger>
+          <SelectContent>
+            {facets.traditionality.map(trad => (
+              <SelectItem key={trad} value={trad}>
+                {trad}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={filters.prepLevel}
+          onValueChange={value => setFilters(f => ({ ...f, prepLevel: value }))}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Prep level" />
+          </SelectTrigger>
+          <SelectContent>
+            {facets.prepLevel.map(level => (
+              <SelectItem key={level} value={level}>
+                {level}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={filters.skillsDeveloped}
+          onValueChange={value => setFilters(f => ({ ...f, skillsDeveloped: value }))}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Skill" />
+          </SelectTrigger>
+          <SelectContent>
+            {facets.skillsDeveloped.map(skill => (
+              <SelectItem key={skill} value={skill}>
+                {skill}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={filters.regionalPopularity}
+          onValueChange={value => setFilters(f => ({ ...f, regionalPopularity: value }))}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Region" />
+          </SelectTrigger>
+          <SelectContent>
+            {facets.regionalPopularity.map(region => (
+              <SelectItem key={region} value={region}>
+                {region}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
+      <div ref={parentRef} className="h-[80vh] overflow-y-auto">
+        <div
+          style={{
+            height: `${rowVirtualizer.getTotalSize()}px`,
+            width: '100%',
+            position: 'relative',
+          }}
+        >
+          {rowVirtualizer.getVirtualItems().map(virtualItem => {
+            const game = filteredGames[virtualItem.index];
+            return (
+              <div
+                key={game.id}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: `${virtualItem.size}px`,
+                  transform: `translateY(${virtualItem.start}px)`,
+                }}
+                className="p-2"
+              >
+                <Card>
+                  <CardHeader>
+                    <Link href={`/game/${game.id}`}>
+                      <CardTitle>{game.name}</CardTitle>
+                    </Link>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground line-clamp-2">
+                      {game.description}
+                    </p>
+                    <div className="mt-2">
+                      {game.tags
+                        .slice(0, 3)
+                        .map(tag => (
+                          <Badge
+                            key={tag}
+                            variant="secondary"
+                            className="mr-1"
+                          >
+                            {tag}
+                          </Badge>
+                        ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      {filteredGames.length === 0 && (
+        <p className="text-center text-muted-foreground">No games found.</p>
+      )}
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -21,7 +21,10 @@
 
     --background: var(--color-neutral-50);
     --foreground: var(--color-neutral-900);
+    --spacing-base: 8px;
     --radius: 16px;
+    --shadow-subtle: 0 1px 2px rgb(0 0 0 / 0.05);
+    --border-width: 1px;
     --focus-ring: oklch(0.7 0.2 150);
   }
 
@@ -32,6 +35,7 @@
 
   * {
     border-color: var(--color-neutral-200);
+    border-width: var(--border-width);
   }
 
   body {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,20 +29,18 @@ export default function HomePage() {
   };
 
   return (
-    <section>
-      <div className="text-center">
-        <h1 className="text-4xl font-extrabold tracking-tighter lg:text-5xl">
-          Find Your Next Favourite Game
-        </h1>
-        <p className="mx-auto mt-4 max-w-[700px] text-lg text-muted-foreground">
+    <section className="space-y-10">
+      <div className="mx-auto max-w-2xl text-center">
+        <h1 className="text-primary">Find Your Next Favourite Game</h1>
+        <p className="mt-4 text-lg text-muted-foreground">
           Find the perfect game for any group, age, and space.
         </p>
       </div>
-      <div className="mt-8">
-        <Suspense fallback={<div>Loading filters...</div>}>
-            <GameClient allGames={games} facets={facets} />
-        </Suspense>
-      </div>
+      <Suspense
+        fallback={<div className="text-center text-muted-foreground">Loading games...</div>}
+      >
+        <GameClient allGames={games} facets={facets} />
+      </Suspense>
     </section>
   );
 }

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -20,7 +20,14 @@ export const tokens = {
     heading: 'Outfit',
     body: 'Inter',
   },
+  spacing: '8px',
   radius: '16px',
+  shadow: '0 1px 2px rgb(0 0 0 / 0.05)',
+  borderWidth: '1px',
+  motion: {
+    duration: '150ms',
+    easing: 'ease-in-out',
+  },
   focus: 'oklch(0.7 0.2 150)',
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -47,10 +47,14 @@ const config = {
         sm: 'calc(var(--radius) - 8px)',
       },
       boxShadow: {
-        subtle: '0 1px 2px rgb(0 0 0 / 0.05)',
+        subtle: 'var(--shadow-subtle)',
+      },
+      borderWidth: {
+        DEFAULT: 'var(--border-width)',
       },
       transitionDuration: {
         DEFAULT: '150ms',
+        200: '200ms',
       },
       transitionTimingFunction: {
         DEFAULT: 'ease-in-out',


### PR DESCRIPTION
## Summary
- style homepage hero using design tokens
- add search bar with dropdown filters for key game facets
- filter and persist selections via URL params
- fix regional popularity filter to handle array comparison

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6e81feca48321807002e1f7653bb3