### PR TITLE
Revamp game catalogue UI with design system

### DIFF
--- a/app/game-client.tsx
+++ b/app/game-client.tsx
@@ -1,64 +1,80 @@
-
 // app/game-client.tsx
-'use client';
+"use client";
 
-import { Game } from '@/lib/types';
-import { useSearchParams, useRouter, usePathname } from 'next/navigation';
-import { useEffect, useState, useMemo, useRef } from 'react';
-import { useDebounce } from 'use-debounce';
-import Fuse from 'fuse.js';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import { Input } from '@/components/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import Link from 'next/link';
+import { Game } from "@/lib/types";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useEffect, useState, useMemo } from "react";
+import { useDebounce } from "use-debounce";
+import Fuse from "fuse.js";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import { Button } from "@/components/ui/button";
+import Image from "next/image";
 
-// Assume Fuse.js is dynamically imported in a real app for performance
 const fuseOptions = {
-  keys: ['name', 'description', 'keywords'],
+  keys: ["name", "description", "keywords"],
   includeScore: true,
   includeMatches: true,
   threshold: 0.4,
 };
 
-// Main Client Component
-export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Record<string, string[]> }) {
+type Facets = Record<string, string[]>;
+
+export function GameClient({
+  allGames,
+  facets,
+}: {
+  allGames: Game[];
+  facets: Facets;
+}) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const perPage = 12;
 
-  // State from URL
   const [filters, setFilters] = useState({
-    query: searchParams.get('q') || '',
-    sort: searchParams.get('sort') || 'name_asc',
-    age: searchParams.get('age')?.split(',').map(Number) || [0, 99],
-    players: searchParams.get('players')?.split(',').map(Number) || [1, 99],
-    category: searchParams.get('category') || '',
-    tags: searchParams.get('tags') || '',
-    traditionality: searchParams.get('traditionality') || '',
-    prepLevel: searchParams.get('prepLevel') || '',
-    skillsDeveloped: searchParams.get('skillsDeveloped') || '',
-    regionalPopularity: searchParams.get('regionalPopularity') || '',
+    query: searchParams.get("q") || "",
+    category: searchParams.get("category") || "",
+    tags: searchParams.get("tags") || "",
+    traditionality: searchParams.get("traditionality") || "",
+    prepLevel: searchParams.get("prepLevel") || "",
+    skillsDeveloped: searchParams.get("skillsDeveloped") || "",
+    regionalPopularity: searchParams.get("regionalPopularity") || "",
+    page: Number(searchParams.get("page")) || 1,
   });
 
   const [debouncedQuery] = useDebounce(filters.query, 300);
 
-  // Memoized filtering logic
   const filteredGames = useMemo(() => {
     let result = allGames;
 
-    // 1. Fuse.js search
     if (debouncedQuery) {
       const fuse = new Fuse(allGames, fuseOptions);
-      result = fuse.search(debouncedQuery).map(res => res.item);
+      result = fuse.search(debouncedQuery).map((res) => res.item);
     }
 
-    // 2. Facet filtering
-    result = result.filter(game => {
+    result = result.filter((game) => {
       if (filters.category && game.category !== filters.category) return false;
       if (filters.tags && !(game.tags || []).includes(filters.tags)) return false;
-      if (filters.traditionality && game.traditionality !== filters.traditionality) return false;
+      if (filters.traditionality && game.traditionality !== filters.traditionality)
+        return false;
       if (filters.prepLevel && game.prepLevel !== filters.prepLevel) return false;
       if (
         filters.skillsDeveloped &&
@@ -70,63 +86,75 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
         !(game.regionalPopularity || []).includes(filters.regionalPopularity)
       )
         return false;
-
       return true;
-    });
-
-    // 3. Sorting
-    result.sort((a, b) => {
-        if (filters.sort === 'name_asc') return a.name.localeCompare(b.name);
-        if (filters.sort === 'age_asc') return (a.ageMin || 99) - (b.ageMin || 99);
-        // ... other sorts
-        return 0;
     });
 
     return result;
   }, [allGames, debouncedQuery, filters]);
 
-  // Effect to update URL when filters change
+  const totalPages = Math.ceil(filteredGames.length / perPage);
+  const currentPage = Math.min(filters.page, totalPages || 1);
+  const paginatedGames = filteredGames.slice(
+    (currentPage - 1) * perPage,
+    currentPage * perPage
+  );
+
   useEffect(() => {
     const params = new URLSearchParams();
-    if (filters.query) params.set('q', filters.query);
-    if (filters.sort !== 'name_asc') params.set('sort', filters.sort);
-    if (filters.category) params.set('category', filters.category);
-    if (filters.tags) params.set('tags', filters.tags);
-    if (filters.traditionality) params.set('traditionality', filters.traditionality);
-    if (filters.prepLevel) params.set('prepLevel', filters.prepLevel);
-    if (filters.skillsDeveloped) params.set('skillsDeveloped', filters.skillsDeveloped);
-    if (filters.regionalPopularity) params.set('regionalPopularity', filters.regionalPopularity);
-    // ... set other params
+    if (filters.query) params.set("q", filters.query);
+    if (filters.category) params.set("category", filters.category);
+    if (filters.tags) params.set("tags", filters.tags);
+    if (filters.traditionality)
+      params.set("traditionality", filters.traditionality);
+    if (filters.prepLevel) params.set("prepLevel", filters.prepLevel);
+    if (filters.skillsDeveloped)
+      params.set("skillsDeveloped", filters.skillsDeveloped);
+    if (filters.regionalPopularity)
+      params.set("regionalPopularity", filters.regionalPopularity);
+    if (currentPage > 1) params.set("page", String(currentPage));
     router.replace(`${pathname}?${params.toString()}`);
-  }, [filters, pathname, router]);
+  }, [filters, pathname, router, currentPage]);
 
-  // Virtualization setup
-  const parentRef = useRef<HTMLDivElement>(null);
-  const rowVirtualizer = useVirtualizer({
-    count: filteredGames.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => 150, // Estimate row height
-    overscan: 5,
-  });
+  const handlePageChange = (page: number) => {
+    setFilters((f) => ({ ...f, page }));
+  };
+
+  const resetFilters = () => {
+    setFilters({
+      query: "",
+      category: "",
+      tags: "",
+      traditionality: "",
+      prepLevel: "",
+      skillsDeveloped: "",
+      regionalPopularity: "",
+      page: 1,
+    });
+  };
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center gap-4">
+      <div className="flex flex-col gap-4 md:flex-row md:flex-wrap">
         <Input
+          aria-label="Search games"
           placeholder="Search by name..."
           value={filters.query}
-          onChange={(e) => setFilters(f => ({ ...f, query: e.target.value }))}
-          className="w-full sm:max-w-xs"
+          onChange={(e) =>
+            setFilters((f) => ({ ...f, query: e.target.value, page: 1 }))
+          }
+          className="md:w-64"
         />
         <Select
           value={filters.category}
-          onValueChange={value => setFilters(f => ({ ...f, category: value }))}
+          onValueChange={(value) =>
+            setFilters((f) => ({ ...f, category: value, page: 1 }))
+          }
         >
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="Category" />
+          <SelectTrigger className="w-40" aria-label="Group">
+            <SelectValue placeholder="Group" />
           </SelectTrigger>
           <SelectContent>
-            {facets.category.map(cat => (
+            {facets.category.map((cat) => (
               <SelectItem key={cat} value={cat}>
                 {cat}
               </SelectItem>
@@ -135,13 +163,15 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
         </Select>
         <Select
           value={filters.tags}
-          onValueChange={value => setFilters(f => ({ ...f, tags: value }))}
+          onValueChange={(value) =>
+            setFilters((f) => ({ ...f, tags: value, page: 1 }))
+          }
         >
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="Tag" />
+          <SelectTrigger className="w-40" aria-label="Type">
+            <SelectValue placeholder="Type" />
           </SelectTrigger>
           <SelectContent>
-            {facets.tags.map(tag => (
+            {facets.tags.map((tag) => (
               <SelectItem key={tag} value={tag}>
                 {tag}
               </SelectItem>
@@ -150,13 +180,15 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
         </Select>
         <Select
           value={filters.traditionality}
-          onValueChange={value => setFilters(f => ({ ...f, traditionality: value }))}
+          onValueChange={(value) =>
+            setFilters((f) => ({ ...f, traditionality: value, page: 1 }))
+          }
         >
-          <SelectTrigger className="w-[180px]">
+          <SelectTrigger className="w-40" aria-label="Traditionality">
             <SelectValue placeholder="Traditionality" />
           </SelectTrigger>
           <SelectContent>
-            {facets.traditionality.map(trad => (
+            {facets.traditionality.map((trad) => (
               <SelectItem key={trad} value={trad}>
                 {trad}
               </SelectItem>
@@ -165,13 +197,15 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
         </Select>
         <Select
           value={filters.prepLevel}
-          onValueChange={value => setFilters(f => ({ ...f, prepLevel: value }))}
+          onValueChange={(value) =>
+            setFilters((f) => ({ ...f, prepLevel: value, page: 1 }))
+          }
         >
-          <SelectTrigger className="w-[180px]">
+          <SelectTrigger className="w-40" aria-label="Prep level">
             <SelectValue placeholder="Prep level" />
           </SelectTrigger>
           <SelectContent>
-            {facets.prepLevel.map(level => (
+            {facets.prepLevel.map((level) => (
               <SelectItem key={level} value={level}>
                 {level}
               </SelectItem>
@@ -180,13 +214,15 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
         </Select>
         <Select
           value={filters.skillsDeveloped}
-          onValueChange={value => setFilters(f => ({ ...f, skillsDeveloped: value }))}
+          onValueChange={(value) =>
+            setFilters((f) => ({ ...f, skillsDeveloped: value, page: 1 }))
+          }
         >
-          <SelectTrigger className="w-[180px]">
+          <SelectTrigger className="w-40" aria-label="Skill">
             <SelectValue placeholder="Skill" />
           </SelectTrigger>
           <SelectContent>
-            {facets.skillsDeveloped.map(skill => (
+            {facets.skillsDeveloped.map((skill) => (
               <SelectItem key={skill} value={skill}>
                 {skill}
               </SelectItem>
@@ -195,13 +231,15 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
         </Select>
         <Select
           value={filters.regionalPopularity}
-          onValueChange={value => setFilters(f => ({ ...f, regionalPopularity: value }))}
+          onValueChange={(value) =>
+            setFilters((f) => ({ ...f, regionalPopularity: value, page: 1 }))
+          }
         >
-          <SelectTrigger className="w-[180px]">
+          <SelectTrigger className="w-40" aria-label="Region">
             <SelectValue placeholder="Region" />
           </SelectTrigger>
           <SelectContent>
-            {facets.regionalPopularity.map(region => (
+            {facets.regionalPopularity.map((region) => (
               <SelectItem key={region} value={region}>
                 {region}
               </SelectItem>
@@ -209,62 +247,115 @@ export function GameClient({ allGames, facets }: { allGames: Game[]; facets: Rec
           </SelectContent>
         </Select>
       </div>
-      <div ref={parentRef} className="h-[80vh] overflow-y-auto">
-        <div
-          style={{
-            height: `${rowVirtualizer.getTotalSize()}px`,
-            width: '100%',
-            position: 'relative',
-          }}
-        >
-          {rowVirtualizer.getVirtualItems().map(virtualItem => {
-            const game = filteredGames[virtualItem.index];
-            return (
-              <div
-                key={game.id}
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  height: `${virtualItem.size}px`,
-                  transform: `translateY(${virtualItem.start}px)`,
-                }}
-                className="p-2"
-              >
-                <Card>
-                  <CardHeader>
-                    <Link href={`/game/${game.id}`}>
-                      <CardTitle>{game.name}</CardTitle>
-                    </Link>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-sm text-muted-foreground line-clamp-2">
-                      {game.description}
-                    </p>
-                    <div className="mt-2">
-                      {game.tags
-                        .slice(0, 3)
-                        .map(tag => (
-                          <Badge
-                            key={tag}
-                            variant="secondary"
-                            className="mr-1"
-                          >
-                            {tag}
-                          </Badge>
-                        ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            );
-          })}
+
+      {paginatedGames.length > 0 ? (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {paginatedGames.map((game) => (
+            <Card
+              key={game.id}
+              className="transition-transform hover:-translate-y-1 hover:shadow-subtle"
+            >
+              <CardHeader className="pb-2">
+                <CardTitle className="text-xl">
+                  <Link href={`/game/${game.id}`} className="hover:underline">
+                    {game.name}
+                  </Link>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-sm text-muted-foreground line-clamp-3">
+                  {game.description}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {typeof game.ageMin === "number" && (
+                    <Badge variant="secondary">
+                      Ages {game.ageMin}
+                      {typeof game.ageMax === "number" ? `–${game.ageMax}` : "+"}
+                    </Badge>
+                  )}
+                  {typeof game.playersMin === "number" && (
+                    <Badge variant="secondary">
+                      {game.playersMin}
+                      {typeof game.playersMax === "number"
+                        ? `–${game.playersMax}`
+                        : "+"} players
+                    </Badge>
+                  )}
+                  {game.prepLevel && (
+                    <Badge variant="secondary">{game.prepLevel}</Badge>
+                  )}
+                  {game.traditionality && (
+                    <Badge variant="secondary">{game.traditionality}</Badge>
+                  )}
+                </div>
+                {game.tags.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {game.tags.slice(0, 3).map((tag) => (
+                      <Badge key={tag} variant="outline">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
         </div>
-      </div>
-      {filteredGames.length === 0 && (
-        <p className="text-center text-muted-foreground">No games found.</p>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <Image
+            src="/file.svg"
+            alt="No games"
+            width={120}
+            height={120}
+            className="mb-6 opacity-80"
+          />
+          <p className="mb-4 text-muted-foreground">
+            No games found. Try adjusting your filters.
+          </p>
+          <Button onClick={resetFilters}>Reset filters</Button>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <Pagination className="pt-4">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  handlePageChange(Math.max(1, currentPage - 1));
+                }}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }).map((_, i) => (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handlePageChange(i + 1);
+                  }}
+                  isActive={currentPage === i + 1}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  handlePageChange(Math.min(totalPages, currentPage + 1));
+                }}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
       )}
     </div>
   );
 }
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { games } from '@/lib/loadGames';
 import { GameClient } from './game-client';
 import { Game } from '@/lib/types';
 import { Suspense } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
 
 // Helper to get unique facet values
 const getUniqueValues = (games: Game[], key: keyof Game) => {
@@ -29,7 +30,7 @@ export default function HomePage() {
   };
 
   return (
-    <section className="space-y-10">
+    <section className="space-y-12">
       <div className="mx-auto max-w-2xl text-center">
         <h1 className="text-primary">Find Your Next Favourite Game</h1>
         <p className="mt-4 text-lg text-muted-foreground">
@@ -37,7 +38,13 @@ export default function HomePage() {
         </p>
       </div>
       <Suspense
-        fallback={<div className="text-center text-muted-foreground">Loading games...</div>}
+        fallback={
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-40 rounded-lg" />
+            ))}
+          </div>
+        }
       >
         <GameClient allGames={games} facets={facets} />
       </Suspense>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -7,28 +7,30 @@ import { Moon, Sun } from 'lucide-react';
 
 export function Header() {
   const { setTheme, theme } = useTheme();
+
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-14 items-center">
-        <div className="mr-4 flex">
-          <Link href="/" className="mr-6 flex items-center space-x-2">
-            <span className="font-bold">itsallfunandgames</span>
+    <header className="sticky top-0 z-50 w-full border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="container flex h-16 items-center justify-between">
+        <Link
+          href="/"
+          className="font-heading text-2xl font-bold text-primary transition-colors hover:text-secondary"
+        >
+          itsallfunandgames
+        </Link>
+        <nav className="flex items-center gap-6 text-sm font-medium">
+          <Link href="/data/quality" className="hover:text-secondary">
+            Diagnostics
           </Link>
-          <nav className="flex items-center space-x-6 text-sm font-medium">
-             <Link href="/data/quality">Diagnostics</Link>
-          </nav>
-        </div>
-        <div className="flex flex-1 items-center justify-end">
           <Button
             variant="ghost"
             size="icon"
             onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
             aria-label="Toggle theme"
           >
-            <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-            <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+            <Sun className="h-5 w-5 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
+            <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />
           </Button>
-        </div>
+        </nav>
       </div>
     </header>
   );

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -1,0 +1,75 @@
+import * as React from "react"
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+export function PaginationContent({ className, ...props }: React.ComponentProps<"ul">) {
+  return <ul className={cn("flex flex-row items-center gap-1", className)} {...props} />
+}
+
+export function PaginationItem({ className, ...props }: React.ComponentProps<"li">) {
+  return <li className={cn("", className)} {...props} />
+}
+
+export function PaginationLink(
+  { className, isActive = false, ...props }: React.ComponentProps<"a"> & { isActive?: boolean }
+) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "flex h-8 w-8 items-center justify-center rounded-md border bg-background p-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2",
+        isActive && "bg-accent text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function PaginationPrevious({ className, ...props }: React.ComponentProps<"a">) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      className={cn("gap-1 pr-2", className)}
+      {...props}
+    >
+      <ChevronLeft className="h-4 w-4" />
+    </PaginationLink>
+  )
+}
+
+export function PaginationNext({ className, ...props }: React.ComponentProps<"a">) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      className={cn("gap-1 pl-2", className)}
+      {...props}
+    >
+      <ChevronRight className="h-4 w-4" />
+    </PaginationLink>
+  )
+}
+
+export function PaginationEllipsis({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn("flex h-8 w-8 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+


### PR DESCRIPTION
## Summary
- restyled header with brand fonts and theme toggle
- redesigned game catalogue with filters, grid cards, empty state and pagination
- added shared pagination component and skeleton loading grid

## Testing
- `npm run lint`
- `npx vitest run` *(fails: Playwright Test did not expect test.beforeEach())*

------
https://chatgpt.com/codex/tasks/task_e_68b6eeae33e48321b4dcb3d189dc42af