### PR TITLE
Revamp homepage container and hero styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -49,6 +49,16 @@
     --border-width: 1px;
     --focus-ring: oklch(0.7 0.2 150);
     --body-background-image: url("/Itsallfunandgames/bg_light.png");
+    --body-overlay: radial-gradient(
+        circle at 15% 20%,
+        rgba(255, 255, 255, 0.9),
+        rgba(255, 255, 255, 0.45) 55%
+      ),
+      radial-gradient(
+        circle at 85% 80%,
+        rgba(255, 237, 213, 0.65),
+        rgba(255, 237, 213, 0)
+      );
   }
 
   .dark {
@@ -72,6 +82,16 @@
     --input: 217 32% 17%;
     --ring: 150 62% 58%;
     --body-background-image: url("/Itsallfunandgames/bg_dark.png");
+    --body-overlay: radial-gradient(
+        circle at 15% 20%,
+        rgba(15, 23, 42, 0.88),
+        rgba(15, 23, 42, 0.6) 60%
+      ),
+      radial-gradient(
+        circle at 80% 85%,
+        rgba(76, 29, 149, 0.35),
+        rgba(15, 23, 42, 0)
+      );
   }
 
   /* Avoid putting borders on EVERYTHING */
@@ -87,8 +107,11 @@
     line-height: 26px;
 
     /* Background image */
-    background-image: var(--body-background-image); /* file in /public */
-    background-repeat: repeat; /* tile the pattern */
+    background-image: var(--body-overlay), var(--body-background-image);
+    background-repeat: no-repeat, repeat; /* gradient overlay + tiled pattern */
+    background-size: cover, 260px;
+    background-attachment: fixed, fixed;
+    background-position: center, top left;
   }
 
   /* The CSS variable above flips to the dark texture when `.dark` is active */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,7 +30,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           storageKey="itsallfunandgames-theme"
         >
           <Header />
-          <main className="container mx-auto px-4 py-8">{children}</main>
+          <main className="container mx-auto max-w-6xl px-4 py-10">
+            <div
+              className="relative z-0 overflow-hidden rounded-[2.75rem] border border-white/60 bg-white/80 p-6 shadow-[0_20px_60px_rgba(15,23,42,0.12)] ring-1 ring-black/5 backdrop-blur supports-[backdrop-filter]:bg-white/65 dark:border-white/10 dark:bg-slate-950/70 dark:ring-white/5 md:p-10"
+            >
+              <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-emerald-200/40 via-transparent to-rose-200/50 dark:from-emerald-400/10 dark:via-transparent dark:to-rose-500/20" />
+              {children}
+            </div>
+          </main>
 
           {/* Toasts (Sonner via shadcn wrapper) */}
           <Toaster richColors position="top-right" duration={3000} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,11 +30,17 @@ export default function HomePage() {
   };
 
   return (
-    <section className="space-y-12">
-      <div className="mx-auto max-w-2xl text-center">
-        <h1 className="text-primary">Find Your Next Favourite Game</h1>
-        <p className="mt-4 text-lg text-muted-foreground">
-          Find the perfect game for any group, age, and space.
+    <section className="relative z-10 space-y-12 sm:space-y-16">
+      <div className="mx-auto max-w-3xl text-center">
+        <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-primary shadow-sm">
+          <span aria-hidden="true">🎲</span>
+          Game night inspiration
+        </span>
+        <h1 className="text-4xl font-black tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+          Find Your Next Favourite Game
+        </h1>
+        <p className="mt-4 text-lg text-muted-foreground sm:text-xl">
+          Browse curated activities, mix and match filters, and plan unforgettable play sessions for any group, age, or space.
         </p>
       </div>
       <Suspense


### PR DESCRIPTION
## Summary
- layer a soft gradient over the tiled background in light and dark themes for better contrast
- wrap the app content in a frosted-glass style container to separate cards from the page texture
- refresh the homepage hero copy with a badge and larger typography for improved hierarchy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc3565304c832198f7d298f2c4f045