### PR TITLE
Redesign game client layout for responsive filters

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -109,7 +109,7 @@
     /* Background image */
     background-image: var(--body-overlay), var(--body-background-image);
     background-repeat: no-repeat, repeat; /* gradient overlay + tiled pattern */
-    background-size: cover, 260px;
+    background-size: cover, auto;
     background-attachment: fixed, fixed;
     background-position: center, top left;
   }


### PR DESCRIPTION
## Summary
- replace the side filter layout with a reusable panel component that supports mobile overlays and integrated search
- restyle the main game listing area with a two-column responsive layout, refreshed typography, and clickable game cards
- adjust helper UI elements such as info badges and dynamic headings to match the updated colour palette

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d24bdcd4908321ad8bc2101a355151