### PR TITLE
Adjust main page layout to use percentage widths

### DIFF
--- a/app/game-client.tsx
+++ b/app/game-client.tsx
@@ -766,12 +766,17 @@ export function GameClient({
           "mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-10"
         )}
       >
-        <aside className={cn(styles.desktopFilters, "w-full max-w-xs flex-shrink-0")}>
+        <aside
+          className={cn(
+            styles.desktopFilters,
+            "w-full flex-shrink-0 lg:basis-[20%] lg:w-[20%]"
+          )}
+        >
           <div className="sticky top-6 rounded-3xl border border-[#80B380]/30 bg-white/80 p-6 shadow-sm backdrop-blur">
             {renderFilterPanel("desktop")}
           </div>
         </aside>
-        <main className="flex w-full flex-1 flex-col gap-8">
+        <main className="flex w-full flex-1 flex-col gap-8 lg:basis-[80%]">
           <div className="rounded-3xl border border-[#80B380]/20 bg-white/70 p-6 shadow-sm backdrop-blur">
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div>


### PR DESCRIPTION
## Summary
- switch the desktop filter aside to a percentage-based width for better responsiveness
- allocate the main content area the remaining width to complement the new sidebar sizing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2666b16c4832190bac9c30f61c5ff