### PR TITLE
Move search bar to layout header

### DIFF
--- a/app/game-client.module.css
+++ b/app/game-client.module.css
@@ -16,58 +16,6 @@
   }
 }
 
-.desktopFilters {
-  display: none;
-}
-
-@media (min-width: 1024px) {
-  .desktopFilters {
-    display: block;
-  }
-}
-
-.mobileFiltersButton {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-@media (min-width: 1024px) {
-  .mobileFiltersButton {
-    display: none;
-  }
-}
-
-.mobileHint {
-  display: block;
-}
-
-@media (min-width: 1024px) {
-  .mobileHint {
-    display: none;
-  }
-}
-
-.mobileFiltersOverlay {
-  display: flex;
-}
-
-@media (min-width: 1024px) {
-  .mobileFiltersOverlay {
-    display: none;
-  }
-}
-
-.mobileFiltersSheet {
-  width: 100%;
-}
-
-@media (min-width: 640px) {
-  .mobileFiltersSheet {
-    width: 420px;
-  }
-}
-
 @media (min-width: 640px) {
   .heading {
     font-size: 1.875rem;


### PR DESCRIPTION
## Summary
- move the main game search control into a new header bar so it stays at the top of the layout
- tidy the filter rail introduction now that the search lives in the header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f572155883219f87283c996554a3