### PR TITLE
Add markdown rendering for game rules

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { games } from '@/lib/loadGames';
 import { notFound } from 'next/navigation';
 import { Badge } from '@/components/ui/badge';
+import { Markdown } from '@/components/markdown';
 
 type Props = {
   params: { id: string };
@@ -53,7 +54,9 @@ export default function GameDetailPage({ params }: Props) {
             <h3>Rules</h3>
             <ol>
               {game.generalRules.map((rule, i) => (
-                <li key={i}>{rule}</li>
+                <li key={i}>
+                  <Markdown content={rule} />
+                </li>
               ))}
             </ol>
           </div>

--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -1,0 +1,19 @@
+import ReactMarkdown from 'react-markdown';
+
+type MarkdownProps = {
+  content: string;
+};
+
+export function Markdown({ content }: MarkdownProps) {
+  return (
+    <ReactMarkdown
+      components={{
+        p({ children }) {
+          return <>{children}</>;
+        },
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-markdown": "^9.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- add the `react-markdown` dependency for Markdown rendering support
- introduce a Markdown helper component that strips the default paragraph wrapper
- render game rules through the helper so Markdown formatting like bold works in ordered lists

## Testing
- npm install *(fails: 403 Forbidden when fetching react-markdown due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfe00a5ac8321be3ccca1cb4ad165