### PR TITLE
Fix general rules markdown rendering

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -52,13 +52,11 @@ export default function GameDetailPage({ params }: Props) {
         {game.generalRules && game.generalRules.length > 0 && (
           <div>
             <h3>Rules</h3>
-            <ol>
+            <div className="space-y-4">
               {game.generalRules.map((rule, i) => (
-                <li key={i}>
-                  <Markdown content={rule} />
-                </li>
+                <Markdown key={i} content={rule} />
               ))}
-            </ol>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- remove ordered list wrapper around general rules so Markdown content renders as authored
- add spacing between rendered rule sections for readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc05ac310c832195fa60cb80409848