### PR TITLE
Restyle game cards for improved readability

### DIFF
--- a/app/game-client.tsx
+++ b/app/game-client.tsx
@@ -236,11 +236,11 @@ const filterMeta: Record<
 };
 
 const InfoItem = ({ icon: Icon, label }: { icon: LucideIcon; label: string }) => (
-  <div className="flex items-center gap-3 rounded-2xl bg-brand-sprout/10 px-3 py-2 text-sm font-medium text-brand-ink">
-    <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-sprout/20 text-brand-sprout">
+  <div className="flex items-center gap-3 rounded-xl border border-brand-sprout/20 bg-white/85 px-3 py-2 text-sm font-medium text-brand-ink shadow-sm">
+    <span className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-sprout/15 text-brand-sprout">
       <Icon className="h-4 w-4" />
     </span>
-    <span className="min-w-0 flex-1 break-words">{label}</span>
+    <span className="min-w-0 flex-1 break-words leading-snug">{label}</span>
   </div>
 );
 
@@ -978,96 +978,116 @@ export function GameClient({
                   <Link
                     key={game.id}
                     href={`/game/${game.id}`}
-                    className="group flex h-full flex-col justify-between rounded-3xl border border-brand-sprout/25 bg-white/90 p-6 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-marigold focus-visible:ring-offset-2 focus-visible:ring-offset-brand-parchment/60"
+                    className="group relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border border-brand-sprout/25 bg-white/95 p-6 text-left shadow-sm transition-all duration-200 no-underline hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-marigold focus-visible:ring-offset-2 focus-visible:ring-offset-brand-parchment/60"
                   >
-                    <div className="flex flex-col gap-4">
-                      <div className="flex flex-wrap items-start gap-3">
-                        <div className="min-w-0 flex-1">
-                          <h2
-                            className={cn(
-                              styles.cardTitle,
-                              "text-lg font-semibold text-brand-ink transition-colors group-hover:text-brand-sprout"
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br from-brand-sprout/0 via-brand-sprout/5 to-brand-marigold/10 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                    />
+                    <div className="relative flex flex-1 flex-col gap-6">
+                      <header className="flex flex-col gap-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-0 flex-1 space-y-2">
+                            {game.category && (
+                              <span className="inline-flex items-center gap-2 rounded-full bg-brand-sprout/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-brand-sprout">
+                                {prettifyFilterValue(game.category)}
+                              </span>
                             )}
-                          >
-                            {game.name}
-                          </h2>
-                          {game.category && (
-                            <p className="mt-1 text-xs font-semibold uppercase tracking-wide text-brand-sprout">
-                              {prettifyFilterValue(game.category)}
-                            </p>
+                            <h2
+                              className={cn(
+                                styles.cardTitle,
+                                "font-semibold text-brand-ink transition-colors group-hover:text-brand-sprout sm:text-xl"
+                              )}
+                            >
+                              {game.name}
+                            </h2>
+                          </div>
+                          {game.tags.length > 0 && (
+                            <div className="flex flex-wrap justify-end gap-2">
+                              {game.tags.slice(0, 2).map((tag) => (
+                                <Badge
+                                  key={tag}
+                                  variant="outline"
+                                  className="rounded-full border-brand-sprout/25 bg-white/80 px-3 py-1 text-[11px] font-medium uppercase tracking-wide text-brand-sprout"
+                                >
+                                  #{prettifyFilterValue(tag)}
+                                </Badge>
+                              ))}
+                            </div>
                           )}
                         </div>
-                        {game.tags.length > 0 && (
-                          <div className="flex flex-wrap gap-2">
-                            {game.tags.slice(0, 2).map((tag) => (
-                              <Badge
-                                key={tag}
-                                variant="outline"
-                                className="rounded-full border-brand-sprout/30 bg-white px-3 py-1 text-xs font-medium text-brand-sprout"
-                              >
-                                #{prettifyFilterValue(tag)}
-                              </Badge>
-                            ))}
+                        <p className="text-sm leading-6 text-brand-ink/75 line-clamp-4">
+                          {description ||
+                            "Discover the rules, twists, and fun variations for this game."}
+                        </p>
+                      </header>
+
+                      <div className="space-y-4">
+                        <div className="space-y-3 rounded-2xl border border-brand-sprout/20 bg-brand-parchment/70 p-4">
+                          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-brand-ink/70">
+                            <Sparkles className="h-3.5 w-3.5 text-brand-marigold" />
+                            Quick facts
+                          </div>
+                          <div className={cn(styles.infoGrid, "grid gap-3")}>
+                            {playersText && <InfoItem icon={Users} label={playersText} />}
+                            {ageText && <InfoItem icon={Baby} label={ageText} />}
+                            {prepText && <InfoItem icon={Wrench} label={prepText} />}
+                            {traditionText && <InfoItem icon={ScrollText} label={traditionText} />}
+                          </div>
+                        </div>
+
+                        {(topSkills.length > 0 || topRegions.length > 0) && (
+                          <div className="space-y-3 rounded-2xl border border-brand-sprout/15 bg-white/85 p-4 shadow-sm">
+                            {topSkills.length > 0 && (
+                              <div className="space-y-2">
+                                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-brand-ink/70">
+                                  <Sparkles className="h-3.5 w-3.5 text-brand-marigold" />
+                                  Key skills
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                  {topSkills.map((skill) => (
+                                    <Badge
+                                      key={skill}
+                                      variant="outline"
+                                      className="rounded-full border-brand-sprout/25 bg-brand-parchment/80 px-3 py-1 text-[11px] font-medium text-brand-ink"
+                                    >
+                                      {prettifyFilterValue(skill)}
+                                    </Badge>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+                            {topRegions.length > 0 && (
+                              <div className="space-y-2">
+                                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-brand-ink/70">
+                                  <Globe2 className="h-3.5 w-3.5 text-brand-sprout" />
+                                  Popular in
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                  {topRegions.map((region) => (
+                                    <Badge
+                                      key={region}
+                                      className="rounded-full bg-brand-sprout/15 px-3 py-1 text-[11px] font-medium text-brand-ink"
+                                    >
+                                      {region}
+                                    </Badge>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
                           </div>
                         )}
                       </div>
-                      <p className="text-sm leading-6 text-brand-ink/75 line-clamp-4">
-                        {description ||
-                          "Discover the rules, twists, and fun variations for this game."}
-                      </p>
                     </div>
-                    <div className="mt-6 space-y-4">
-                      <div className={cn(styles.infoGrid, "grid gap-3")}>
-                        {playersText && <InfoItem icon={Users} label={playersText} />}
-                        {ageText && <InfoItem icon={Baby} label={ageText} />}
-                        {prepText && <InfoItem icon={Wrench} label={prepText} />}
-                        {traditionText && <InfoItem icon={ScrollText} label={traditionText} />}
-                      </div>
-                      {(topSkills.length > 0 || topRegions.length > 0) && (
-                        <div className="space-y-3 rounded-2xl border border-brand-sprout/20 bg-brand-parchment/60 p-4">
-                          {topSkills.length > 0 && (
-                            <div>
-                              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-brand-ink/70">
-                                <Sparkles className="h-3.5 w-3.5 text-brand-marigold" />
-                                Key skills
-                              </div>
-                              <div className="mt-2 flex flex-wrap gap-2">
-                                {topSkills.map((skill) => (
-                                  <Badge
-                                    key={skill}
-                                    variant="outline"
-                                    className="rounded-full border-brand-sprout/30 bg-white px-3 py-1 text-xs font-medium text-brand-ink"
-                                  >
-                                    {prettifyFilterValue(skill)}
-                                  </Badge>
-                                ))}
-                              </div>
-                            </div>
-                          )}
-                          {topRegions.length > 0 && (
-                            <div>
-                              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-brand-ink/70">
-                                <Globe2 className="h-3.5 w-3.5 text-brand-sprout" />
-                                Popular in
-                              </div>
-                              <div className="mt-2 flex flex-wrap gap-2">
-                                {topRegions.map((region) => (
-                                  <Badge
-                                    key={region}
-                                    className="rounded-full bg-brand-sprout/15 px-3 py-1 text-xs font-medium text-brand-ink"
-                                  >
-                                    {region}
-                                  </Badge>
-                                ))}
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                    <div className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-brand-sprout">
-                      Explore game
-                      <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+
+                    <div className="relative mt-6 flex items-center justify-between border-t border-brand-sprout/20 pt-4 text-sm font-semibold text-brand-sprout">
+                      <span className="inline-flex items-center gap-2">
+                        Explore game
+                        <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+                      </span>
+                      <span className="text-xs font-medium uppercase tracking-wide text-brand-ink/60">
+                        Learn the full rules
+                      </span>
                     </div>
                   </Link>
                 );


### PR DESCRIPTION
## Summary
- refresh the game card layout with gradient hover styling, tidy typography, and a no-underline link treatment so cards feel like surfaces rather than links
- reorganize quick facts, skills, and region callouts into dedicated sections with refined badges for a cleaner hierarchy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6435e366883219fbc0becb0cdacf1