### PR TITLE
Restyle homepage and cards with cosmic review-inspired visual theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -23,81 +23,69 @@
     --color-neutral-900: #0B0F12;
 
     /* shadcn/ui tokens (HSL values) */
-    --background: 52 100% 96%; /* warm light */
-    --foreground: 222 47% 11%;
-    --card: 0 0% 100%;
-    --card-foreground: 222 47% 11%;
+    --background: 218 47% 10%;
+    --foreground: 210 40% 98%;
+    --card: 222 40% 14%;
+    --card-foreground: 210 40% 98%;
     --popover: 0 0% 100%;
     --popover-foreground: 222 47% 11%;
-    --primary: 123 46% 34%; /* #2E7D32 */
-    --primary-foreground: 0 0% 98%;
-    --secondary: 207 75% 46%; /* #1976D2 */
+    --primary: 188 100% 47%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 273 100% 68%;
     --secondary-foreground: 0 0% 100%;
-    --muted: 210 40% 96%;
-    --muted-foreground: 215 16% 47%;
-    --accent: 38 100% 50%; /* #FFB300 */
-    --accent-foreground: 230 25% 15%;
+    --muted: 220 30% 20%;
+    --muted-foreground: 215 20% 78%;
+    --accent: 334 100% 62%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 150 62% 58%;
+    --border: 222 23% 26%;
+    --input: 222 23% 26%;
+    --ring: 188 100% 47%;
 
     --spacing-base: 8px;
     --radius: 16px;
     --shadow-subtle: 0 1px 2px rgb(0 0 0 / 0.05);
     --border-width: 1px;
     --focus-ring: oklch(0.7 0.2 150);
-    --body-background-image: url("/Itsallfunandgames/bg_light.png");
-    --body-overlay: radial-gradient(
-        circle at 15% 20%,
-        rgba(255, 255, 255, 0.9),
-        rgba(255, 255, 255, 0.45) 55%
-      ),
-      radial-gradient(
-        circle at 85% 80%,
-        rgba(255, 237, 213, 0.65),
-        rgba(255, 237, 213, 0)
-      );
+    --body-background-image: none;
+    --body-overlay:
+      radial-gradient(circle at 20% 10%, rgba(34, 211, 238, 0.18), transparent 35%),
+      radial-gradient(circle at 80% 12%, rgba(217, 70, 239, 0.16), transparent 30%),
+      linear-gradient(180deg, #0b1120 0%, #131b33 50%, #0b1020 100%);
 
     /* Semantic Tokens */
-    --surface-sunken: rgba(249, 247, 232, 0.6); /* parchment/60 */
-    --surface-raised: rgba(255, 255, 255, 0.8); /* white/80 */
-    --surface-highlight: rgba(128, 179, 128, 0.15); /* sprout/15 */
-    --text-brand: #4B4B4B; /* brand-ink */
+    --surface-sunken: rgba(15, 23, 42, 0.72);
+    --surface-raised: rgba(30, 41, 59, 0.72);
+    --surface-highlight: rgba(34, 211, 238, 0.18);
+    --text-brand: #e2e8f0;
   }
 
   .dark {
-    --background: 222 47% 7%;
+    --background: 218 47% 10%;
     --foreground: 210 40% 98%;
-    --card: 222 47% 8%;
+    --card: 222 40% 14%;
     --card-foreground: 210 40% 98%;
     --popover: 222 47% 8%;
     --popover-foreground: 210 40% 98%;
-    --primary: 123 53% 46%;
-    --primary-foreground: 0 0% 10%;
-    --secondary: 207 75% 46%;
-    --secondary-foreground: 0 0% 10%;
+    --primary: 188 100% 47%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 273 100% 68%;
+    --secondary-foreground: 0 0% 100%;
     --muted: 217 32% 17%;
     --muted-foreground: 215 20% 65%;
-    --accent: 38 100% 50%;
-    --accent-foreground: 0 0% 10%;
+    --accent: 334 100% 62%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 0 63% 37%;
     --destructive-foreground: 0 0% 98%;
-    --border: 217 32% 17%;
-    --input: 217 32% 17%;
-    --ring: 150 62% 58%;
-    --body-background-image: url("/Itsallfunandgames/bg_dark.png");
-    --body-overlay: radial-gradient(
-        circle at 15% 20%,
-        rgba(15, 23, 42, 0.88),
-        rgba(15, 23, 42, 0.6) 60%
-      ),
-      radial-gradient(
-        circle at 80% 85%,
-        rgba(76, 29, 149, 0.35),
-        rgba(15, 23, 42, 0)
-      );
+    --border: 222 23% 26%;
+    --input: 222 23% 26%;
+    --ring: 188 100% 47%;
+    --body-background-image: none;
+    --body-overlay:
+      radial-gradient(circle at 20% 10%, rgba(34, 211, 238, 0.18), transparent 35%),
+      radial-gradient(circle at 80% 12%, rgba(217, 70, 239, 0.16), transparent 30%),
+      linear-gradient(180deg, #0b1120 0%, #131b33 50%, #0b1020 100%);
       
     /* Dark Mode Semantic Tokens */
     --surface-sunken: rgba(15, 23, 42, 0.5);
@@ -145,4 +133,3 @@
     @apply !transition-none !animate-none;
   }
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,14 +36,14 @@ export default function HomePage() {
   return (
     <section className="relative z-10 space-y-12 sm:space-y-16">
       <div className="mx-auto max-w-3xl text-center">
-        <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-primary shadow-sm">
+        <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-cyan-300/40 bg-cyan-400/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-cyan-200 shadow-sm">
           <span aria-hidden="true">🎲</span>
           Game inspiration
         </span>
-        <h1 className="text-4xl font-black tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+        <h1 className="bg-gradient-to-r from-cyan-200 via-sky-100 to-fuchsia-200 bg-clip-text text-4xl font-black tracking-tight text-transparent sm:text-5xl lg:text-6xl">
           Find Your Next Favourite Game
         </h1>
-        <p className="mt-4 text-lg text-muted-foreground sm:text-xl">
+        <p className="mt-4 text-lg text-slate-300 sm:text-xl">
           Browse curated activities, mix and match filters, and plan unforgettable play sessions for any group, age, or space.
         </p>
       </div>

--- a/components/game/game-card.tsx
+++ b/components/game/game-card.tsx
@@ -6,9 +6,7 @@ import { prettifyFilterValue } from "@/lib/utils";
 import {
     ArrowRight,
     Baby,
-    Globe2,
     ScrollText,
-    Sparkles,
     Users,
     Wrench,
     LucideIcon,
@@ -36,8 +34,8 @@ const InfoItem = ({
     <TooltipProvider>
         <Tooltip>
             <TooltipTrigger asChild>
-                <div className="flex items-center gap-2.5 text-sm font-medium text-text-brand/80 cursor-help">
-                    <Icon className="h-4 w-4 text-brand-sprout" />
+                <div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-300/10 px-2.5 py-1 text-xs font-semibold text-cyan-100/95 cursor-help transition-colors group-hover:border-cyan-200/50 group-hover:bg-cyan-300/20">
+                    <Icon className="h-3.5 w-3.5 text-cyan-200" />
                     <span className="truncate">{label}</span>
                 </div>
             </TooltipTrigger>

--- a/components/game/game-card.tsx
+++ b/components/game/game-card.tsx
@@ -86,7 +86,7 @@ export function GameCard({ game }: GameCardProps) {
     return (
         <Card
             asChild
-            className="group relative flex h-full flex-col overflow-hidden rounded-[32px] border-brand-sprout/20 bg-surface-raised p-0 text-left shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:border-brand-sprout/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-marigold focus-visible:ring-offset-2"
+            className="group relative flex h-full flex-col overflow-hidden rounded-[28px] border-cyan-300/25 bg-slate-900/70 p-0 text-left shadow-[0_10px_30px_rgba(0,0,0,0.35)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_14px_40px_rgba(6,182,212,0.2)] hover:border-cyan-300/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2"
         >
             <Link
                 href={`/game/${game.id}`}
@@ -97,23 +97,23 @@ export function GameCard({ game }: GameCardProps) {
                         <div className="flex items-start justify-between gap-3">
                             <div className="space-y-1.5">
                                 {game.category && (
-                                    <span className="inline-flex items-center rounded-full bg-brand-sprout/10 px-2.5 py-0.5 text-[11px] font-bold uppercase tracking-wider text-brand-sprout">
+                                    <span className="inline-flex items-center rounded-full bg-cyan-300/10 px-2.5 py-0.5 text-[11px] font-bold uppercase tracking-wider text-cyan-200">
                                         {prettifyFilterValue(game.category)}
                                     </span>
                                 )}
-                                <h2 className="font-heading text-xl font-bold text-text-brand transition-colors group-hover:text-brand-sprout sm:text-2xl line-clamp-2">
+                                <h2 className="font-heading text-xl font-bold text-slate-100 transition-colors group-hover:text-cyan-200 sm:text-2xl line-clamp-2">
                                     {game.name}
                                 </h2>
                             </div>
                         </div>
-                        <p className="text-sm leading-relaxed text-text-brand/70 line-clamp-3">
+                        <p className="text-sm leading-relaxed text-slate-300/90 line-clamp-3">
                             {description ||
                                 "Discover the rules, twists, and fun variations for this game."}
                         </p>
                     </header>
 
                     <div className="mt-auto space-y-4">
-                        <div className="grid grid-cols-2 gap-y-2 gap-x-4 rounded-2xl bg-surface-sunken/50 p-3">
+                        <div className="grid grid-cols-2 gap-y-2 gap-x-4 rounded-2xl border border-slate-700/80 bg-slate-950/45 p-3">
                             {playersText && (
                                 <InfoItem
                                     icon={Users}
@@ -150,7 +150,7 @@ export function GameCard({ game }: GameCardProps) {
                                     <Badge
                                         key={skill}
                                         variant="secondary"
-                                        className="rounded-md bg-surface-highlight px-2 py-0.5 text-[10px] font-semibold text-text-brand/80 transition-colors group-hover:bg-brand-sprout/10 group-hover:text-brand-sprout"
+                                        className="rounded-md bg-cyan-300/10 px-2 py-0.5 text-[10px] font-semibold text-cyan-100 transition-colors group-hover:bg-fuchsia-300/20 group-hover:text-fuchsia-100"
                                     >
                                         {prettifyFilterValue(skill)}
                                     </Badge>
@@ -160,7 +160,7 @@ export function GameCard({ game }: GameCardProps) {
                     </div>
                 </div>
 
-                <div className="relative flex items-center justify-between border-t border-brand-sprout/10 bg-surface-sunken/30 px-5 py-3 text-sm font-semibold text-brand-sprout transition-colors group-hover:bg-brand-sprout/5">
+                <div className="relative flex items-center justify-between border-t border-cyan-300/20 bg-slate-950/60 px-5 py-3 text-sm font-semibold text-cyan-200 transition-colors group-hover:bg-cyan-300/10">
                     <span className="inline-flex items-center gap-2">
                         View details
                     </span>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -9,16 +9,16 @@ export function Header() {
   const { setTheme, theme } = useTheme();
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="sticky top-0 z-50 w-full border-b border-cyan-400/20 bg-slate-950/75 backdrop-blur-xl supports-[backdrop-filter]:bg-slate-950/65">
       <div className="container flex h-16 items-center justify-between">
         <Link
           href="/"
-          className="font-heading text-2xl font-bold text-primary transition-colors hover:text-secondary"
+          className="font-heading text-2xl font-bold tracking-tight text-cyan-300 transition-colors hover:text-fuchsia-300"
         >
           itsallfunandgames
         </Link>
-        <nav className="flex items-center gap-6 text-sm font-medium">
-          <Link href="/data/quality" className="hover:text-secondary">
+        <nav className="flex items-center gap-6 text-sm font-medium text-slate-200">
+          <Link href="/data/quality" className="transition-colors hover:text-cyan-300">
             Diagnostics
           </Link>
           <Button


### PR DESCRIPTION
## Summary
- shifted global design tokens toward a dark, neon-accent palette inspired by cosmiccoding reviews styling
- updated page hero styling with gradient headline and brighter accent chip
- refreshed top header to a glassy dark bar with cyan/fuchsia hover accents
- restyled game cards to use darker surfaces, cyan borders, and glowing hover treatments

## Files changed
- `app/globals.css`
- `app/page.tsx`
- `components/header.tsx`
- `components/game/game-card.tsx`

## Notes
- this is a visual restyle only; no data or behavior changes were introduced

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc95dfdc3c83219d2b067ebd5c18e9)