### PR TITLE
Redesign catalogue: large responsive game cards, tag filters, and persistent bookmarks

### DIFF
--- a/app/game-client.tsx
+++ b/app/game-client.tsx
@@ -18,7 +18,7 @@ import {
   PanelLeftOpen,
   X,
 } from "lucide-react";
-import { cn, prettifyFilterValue } from "@/lib/utils";
+import { prettifyFilterValue } from "@/lib/utils";
 import { FacetKey, facetKeys, filterMeta } from "@/lib/constants";
 import { FilterSidebar } from "@/components/game/filter-sidebar";
 import { SearchBar } from "@/components/game/search-bar";
@@ -37,6 +37,7 @@ type Facets = Record<FacetKey, string[]>;
 type FiltersState = {
   query: string;
   page: number;
+  bookmarkedOnly: boolean;
 } & {
   [K in FacetKey]: string[];
 };
@@ -52,6 +53,7 @@ const createEmptySelections = (): Record<FacetKey, string[]> =>
 const createDefaultFilters = (): FiltersState => ({
   query: "",
   page: DEFAULT_PAGE,
+  bookmarkedOnly: false,
   ...createEmptySelections(),
 });
 
@@ -78,6 +80,7 @@ const buildFiltersFromParams = (
   const next = createDefaultFilters();
   next.query = params.get("q") ?? "";
   next.page = parsePageParam(params.get("page"));
+  next.bookmarkedOnly = params.get("bookmarked") === "1";
 
   facetKeys.forEach((key) => {
     const values = params
@@ -100,7 +103,7 @@ const arraysEqual = (a: string[], b: string[]) => {
 };
 
 const areFiltersEqual = (a: FiltersState, b: FiltersState) => {
-  if (a.query !== b.query || a.page !== b.page) return false;
+  if (a.query !== b.query || a.page !== b.page || a.bookmarkedOnly !== b.bookmarkedOnly) return false;
   return facetKeys.every((key) => arraysEqual(a[key], b[key]));
 };
 
@@ -141,6 +144,7 @@ export function GameClient({
   }
 
   const [debouncedQuery] = useDebounce(filters.query, 300);
+  const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set());
 
   const filteredGames = useMemo(() => {
     const trimmedQuery = debouncedQuery.trim();
@@ -149,6 +153,7 @@ export function GameClient({
       : allGames;
 
     return searchResults.filter((game) => {
+      if (filters.bookmarkedOnly && !bookmarkedIds.has(game.id)) return false;
       const {
         category: selectedCategories,
         tags: selectedTags,
@@ -207,7 +212,7 @@ export function GameClient({
 
       return true;
     });
-  }, [allGames, debouncedQuery, filters, fuse]);
+  }, [allGames, debouncedQuery, filters, fuse, bookmarkedIds]);
 
   const totalPages = Math.ceil(filteredGames.length / perPage);
   const currentPage = Math.min(filters.page, totalPages || 1);
@@ -220,6 +225,8 @@ export function GameClient({
     const params = new URLSearchParams();
     const trimmedQuery = filters.query.trim();
     if (trimmedQuery) params.set("q", trimmedQuery);
+
+    if (filters.bookmarkedOnly) params.set("bookmarked", "1");
 
     facetKeys.forEach((key) => {
       filters[key].forEach((value) => {
@@ -303,6 +310,24 @@ export function GameClient({
       return { ...prev, [key]: [], page: DEFAULT_PAGE };
     });
     setFilterSearches((prev) => ({ ...prev, [key]: "" }));
+  };
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("iafg-bookmarks");
+    if (!stored) return;
+    try {
+      const parsed = JSON.parse(stored) as string[];
+      setBookmarkedIds(new Set(parsed));
+    } catch {}
+  }, []);
+
+  const toggleBookmark = (id: string) => {
+    setBookmarkedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      window.localStorage.setItem("iafg-bookmarks", JSON.stringify(Array.from(next)));
+      return next;
+    });
   };
 
   const resetFilters = () => {
@@ -446,6 +471,7 @@ export function GameClient({
 
           <div className="rounded-3xl border border-brand-sprout/20 bg-surface-raised/90 p-6 shadow-sm backdrop-blur">
             <div className="flex flex-wrap items-center justify-between gap-4">
+              <Button type="button" variant={filters.bookmarkedOnly ? "default" : "outline"} className="rounded-full" onClick={() => setFilters((p) => ({...p, bookmarkedOnly: !p.bookmarkedOnly, page: DEFAULT_PAGE}))}>Bookmarked only</Button>
               <div>
                 <h1 className="font-heading text-2xl font-semibold text-text-brand sm:text-3xl">
                   {heading}
@@ -496,7 +522,7 @@ export function GameClient({
             </div>
           )}
 
-          <GameGrid games={paginatedGames} resetFilters={resetFilters} />
+          <GameGrid games={paginatedGames} resetFilters={resetFilters} bookmarkedIds={bookmarkedIds} onToggleBookmark={toggleBookmark} onTagToggle={(value, include) => updateFilterValue("tags", value, include)} activeTags={new Set(filters.tags)} />
 
           <PaginationControl
             currentPage={currentPage}

--- a/components/game/game-card.tsx
+++ b/components/game/game-card.tsx
@@ -1,170 +1,87 @@
-import Link from "next/link";
+import Image from "next/image";
 import { Game } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { prettifyFilterValue } from "@/lib/utils";
-import {
-    ArrowRight,
-    Baby,
-    ScrollText,
-    Users,
-    Wrench,
-    LucideIcon,
-} from "lucide-react";
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipProvider,
-    TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Bookmark, BookmarkCheck } from "lucide-react";
 
 interface GameCardProps {
-    game: Game;
+  game: Game;
+  isBookmarked: boolean;
+  onToggleBookmark: (id: string) => void;
+  onTagToggle: (value: string, include: boolean) => void;
+  activeTags: Set<string>;
 }
 
-const InfoItem = ({
-    icon: Icon,
-    label,
-    tooltip,
-}: {
-    icon: LucideIcon;
-    label: string;
-    tooltip: string;
-}) => (
-    <TooltipProvider>
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-300/10 px-2.5 py-1 text-xs font-semibold text-cyan-100/95 cursor-help transition-colors group-hover:border-cyan-200/50 group-hover:bg-cyan-300/20">
-                    <Icon className="h-3.5 w-3.5 text-cyan-200" />
-                    <span className="truncate">{label}</span>
-                </div>
-            </TooltipTrigger>
-            <TooltipContent>
-                <p>{tooltip}</p>
-            </TooltipContent>
-        </Tooltip>
-    </TooltipProvider>
-);
+const toRange = (min?: number | null, max?: number | null) => {
+  if (typeof min === "number" && typeof max === "number") return `${min}–${max}`;
+  if (typeof min === "number") return `${min}+`;
+  if (typeof max === "number") return `Up to ${max}`;
+  return null;
+};
 
-export function GameCard({ game }: GameCardProps) {
-    const formatPlayers = (game: Game) => {
-        const { playersMin, playersMax } = game;
-        if (typeof playersMin === "number" && typeof playersMax === "number") {
-            return `${playersMin}\u2013${playersMax}`;
-        }
-        if (typeof playersMin === "number") {
-            return `${playersMin}+`;
-        }
-        if (typeof playersMax === "number") {
-            return `Up to ${playersMax}`;
-        }
-        return null;
-    };
+export function GameCard({ game, isBookmarked, onToggleBookmark, onTagToggle, activeTags }: GameCardProps) {
+  const metadata = [
+    toRange(game.playersMin, game.playersMax) && { label: "Players", value: toRange(game.playersMin, game.playersMax) as string },
+    toRange(game.ageMin, game.ageMax) && { label: "Age", value: toRange(game.ageMin, game.ageMax) as string },
+    game.category && { label: "Category", value: prettifyFilterValue(game.category) },
+    game.prepLevel && { label: "Prep", value: prettifyFilterValue(game.prepLevel) },
+    game.equipment && { label: "Equipment", value: game.equipment },
+    ...(game.skillsDeveloped || []).map((s) => ({ label: "Skill", value: prettifyFilterValue(s) })),
+    ...(game.tags || []).map((t) => ({ label: "Tag", value: prettifyFilterValue(t), rawValue: t })),
+    ...(game.regionalPopularity || []).map((r) => ({ label: "Region", value: prettifyFilterValue(r) })),
+    game.traditionality && { label: "Type", value: prettifyFilterValue(game.traditionality) },
+  ].filter(Boolean) as { label: string; value: string; rawValue?: string }[];
 
-    const formatAges = (game: Game) => {
-        const { ageMin, ageMax } = game;
-        if (typeof ageMin === "number" && typeof ageMax === "number") {
-            return `${ageMin}\u2013${ageMax}`;
-        }
-        if (typeof ageMin === "number") {
-            return `${ageMin}+`;
-        }
-        if (typeof ageMax === "number") {
-            return `Up to ${ageMax}`;
-        }
-        return null;
-    };
-
-    const playersText = formatPlayers(game);
-    const ageText = formatAges(game);
-    const prepText = game.prepLevel ? prettifyFilterValue(game.prepLevel) : null;
-    const description = game.description?.trim();
-    const topSkills = (game.skillsDeveloped || []).slice(0, 3);
-
-    return (
-        <Card
-            asChild
-            className="group relative flex h-full flex-col overflow-hidden rounded-[28px] border-cyan-300/25 bg-slate-900/70 p-0 text-left shadow-[0_10px_30px_rgba(0,0,0,0.35)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_14px_40px_rgba(6,182,212,0.2)] hover:border-cyan-300/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2"
+  return (
+    <Card className="overflow-hidden rounded-3xl border border-brand-sprout/25 bg-surface-raised shadow-md transition hover:-translate-y-1 hover:shadow-xl">
+      <div className="relative aspect-[16/9] w-full overflow-hidden bg-gradient-to-br from-brand-sprout/15 via-brand-marigold/15 to-brand-coral/20">
+        {game.image ? (
+          <Image src={game.image} alt={game.name} fill className="object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-center">
+            <div>
+              <p className="text-lg font-semibold text-text-brand/80">{game.name}</p>
+              <p className="text-sm text-text-brand/60">Image coming soon</p>
+            </div>
+          </div>
+        )}
+        <Button
+          type="button"
+          size="icon"
+          variant="secondary"
+          aria-label={isBookmarked ? `Remove ${game.name} from bookmarks` : `Bookmark ${game.name}`}
+          onClick={() => onToggleBookmark(game.id)}
+          className="absolute right-3 top-3 h-9 w-9 rounded-full bg-white/90"
         >
-            <Link
-                href={`/game/${game.id}`}
-                className="flex h-full flex-col text-left text-inherit no-underline"
-            >
-                <div className="flex flex-1 flex-col p-5">
-                    <header className="mb-4 flex flex-col gap-3">
-                        <div className="flex items-start justify-between gap-3">
-                            <div className="space-y-1.5">
-                                {game.category && (
-                                    <span className="inline-flex items-center rounded-full bg-cyan-300/10 px-2.5 py-0.5 text-[11px] font-bold uppercase tracking-wider text-cyan-200">
-                                        {prettifyFilterValue(game.category)}
-                                    </span>
-                                )}
-                                <h2 className="font-heading text-xl font-bold text-slate-100 transition-colors group-hover:text-cyan-200 sm:text-2xl line-clamp-2">
-                                    {game.name}
-                                </h2>
-                            </div>
-                        </div>
-                        <p className="text-sm leading-relaxed text-slate-300/90 line-clamp-3">
-                            {description ||
-                                "Discover the rules, twists, and fun variations for this game."}
-                        </p>
-                    </header>
-
-                    <div className="mt-auto space-y-4">
-                        <div className="grid grid-cols-2 gap-y-2 gap-x-4 rounded-2xl border border-slate-700/80 bg-slate-950/45 p-3">
-                            {playersText && (
-                                <InfoItem
-                                    icon={Users}
-                                    label={playersText}
-                                    tooltip="Number of players"
-                                />
-                            )}
-                            {ageText && (
-                                <InfoItem
-                                    icon={Baby}
-                                    label={ageText}
-                                    tooltip="Recommended age"
-                                />
-                            )}
-                            {prepText && (
-                                <InfoItem
-                                    icon={Wrench}
-                                    label={prepText}
-                                    tooltip="Preparation level"
-                                />
-                            )}
-                            {game.traditionality && (
-                                <InfoItem
-                                    icon={ScrollText}
-                                    label={prettifyFilterValue(game.traditionality)}
-                                    tooltip="Game style"
-                                />
-                            )}
-                        </div>
-
-                        {topSkills.length > 0 && (
-                            <div className="flex flex-wrap gap-1.5">
-                                {topSkills.map((skill) => (
-                                    <Badge
-                                        key={skill}
-                                        variant="secondary"
-                                        className="rounded-md bg-cyan-300/10 px-2 py-0.5 text-[10px] font-semibold text-cyan-100 transition-colors group-hover:bg-fuchsia-300/20 group-hover:text-fuchsia-100"
-                                    >
-                                        {prettifyFilterValue(skill)}
-                                    </Badge>
-                                ))}
-                            </div>
-                        )}
-                    </div>
-                </div>
-
-                <div className="relative flex items-center justify-between border-t border-cyan-300/20 bg-slate-950/60 px-5 py-3 text-sm font-semibold text-cyan-200 transition-colors group-hover:bg-cyan-300/10">
-                    <span className="inline-flex items-center gap-2">
-                        View details
-                    </span>
-                    <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
-                </div>
-            </Link>
-        </Card>
-    );
+          {isBookmarked ? <BookmarkCheck className="h-4 w-4 text-brand-sprout" /> : <Bookmark className="h-4 w-4" />}
+        </Button>
+      </div>
+      <div className="space-y-4 p-5">
+        <h2 className="text-2xl font-bold text-text-brand">{game.name}</h2>
+        <p className="line-clamp-3 text-sm text-text-brand/75">{game.description || "A playful activity for your next group session."}</p>
+        <div className="flex flex-wrap gap-2">
+          {metadata.map((item, index) => {
+            const key = `${item.label}-${item.value}-${index}`;
+            const raw = item.rawValue;
+            const selected = raw ? activeTags.has(raw) : false;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => raw && onTagToggle(raw, !selected)}
+                disabled={!raw}
+                className="disabled:cursor-default"
+              >
+                <Badge className={`rounded-full px-3 py-1 text-xs font-semibold ${selected ? "bg-brand-sprout text-white" : "bg-surface-highlight text-text-brand"}`}>
+                  <span className="mr-1 opacity-75">{item.label}:</span>{item.value}
+                </Badge>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
 }

--- a/components/game/game-grid.tsx
+++ b/components/game/game-grid.tsx
@@ -6,39 +6,37 @@ import styles from "@/app/game-client.module.css";
 import { cn } from "@/lib/utils";
 
 interface GameGridProps {
-    games: Game[];
-    resetFilters: () => void;
+  games: Game[];
+  resetFilters: () => void;
+  bookmarkedIds: Set<string>;
+  onToggleBookmark: (id: string) => void;
+  onTagToggle: (value: string, include: boolean) => void;
+  activeTags: Set<string>;
 }
 
-export function GameGrid({ games, resetFilters }: GameGridProps) {
-    if (games.length === 0) {
-        return (
-            <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-brand-sprout/40 bg-surface-raised p-12 text-center shadow-inner">
-                <Image
-                    src="/file.svg"
-                    alt="No games"
-                    width={120}
-                    height={120}
-                    className="mb-6 opacity-80"
-                />
-                <p className="mb-4 max-w-md text-base text-text-brand/70">
-                    No games matched your filters. Try adjusting your search or start fresh.
-                </p>
-                <Button
-                    onClick={resetFilters}
-                    className="rounded-full bg-brand-marigold px-6 py-2 text-sm font-semibold text-brand-ink transition hover:bg-brand-marigold-dark"
-                >
-                    Reset filters
-                </Button>
-            </div>
-        );
-    }
-
+export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark, onTagToggle, activeTags }: GameGridProps) {
+  if (games.length === 0) {
     return (
-        <div className={cn(styles.gameGrid, "grid gap-6 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3")}>
-            {games.map((game) => (
-                <GameCard key={game.id} game={game} />
-            ))}
-        </div>
+      <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-brand-sprout/40 bg-surface-raised p-12 text-center shadow-inner">
+        <Image src="/file.svg" alt="No games" width={120} height={120} className="mb-6 opacity-80" />
+        <p className="mb-4 max-w-md text-base text-text-brand/70">No games matched your filters. Try adjusting your search or start fresh.</p>
+        <Button onClick={resetFilters} className="rounded-full bg-brand-marigold px-6 py-2 text-sm font-semibold text-brand-ink transition hover:bg-brand-marigold-dark">Reset filters</Button>
+      </div>
     );
+  }
+
+  return (
+    <div className={cn(styles.gameGrid, "grid gap-6 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3")}>
+      {games.map((game) => (
+        <GameCard
+          key={game.id}
+          game={game}
+          isBookmarked={bookmarkedIds.has(game.id)}
+          onToggleBookmark={onToggleBookmark}
+          onTagToggle={onTagToggle}
+          activeTags={activeTags}
+        />
+      ))}
+    </div>
+  );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 export const GameSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1, 'Name is required'),
+  image: z.string().nullable().optional(),
   description: z.string().nullable().optional(),
   category: z.string().nullable().optional(),
   ageMin: z.number().int().nullable().optional(),


### PR DESCRIPTION
### Motivation
- Remodel the existing games catalogue into a modern, card-first browsing experience with richer metadata, image support, and on-card interactions for fast scanning and filtering.

### Description
- Add optional `image` to the `Game` schema to support per-game artwork while preserving existing data-driven loading (`lib/types.ts`).
- Replace the previous card UI with a polished, responsive `GameCard` containing an image/placeholder area, title, description, metadata pills, and a bookmark button with accessible `aria-label`s (`components/game/game-card.tsx`).
- Make card tags clickable to toggle tag filters and visually highlight active tags, and wire those callbacks through a new `GameGrid` props surface (`components/game/game-grid.tsx` and `components/game/game-card.tsx`).
- Implement bookmark persistence using `localStorage`, add a "Bookmarked only" toggle integrated into client-side filtering and URL state (`bookmarked=1`), and apply bookmark filtering in the main `GameClient` flow (`app/game-client.tsx`).
- Minor cleanup and wiring changes to keep behavior data-driven and compatible with the existing sidebar, pagination and search experience (`app/game-client.tsx`).

### Testing
- Ran `npm run lint` which completed; only pre-existing warnings remain and are outside these changes (no new lint errors).
- Ran `npm run build` in this environment; the build failed due to Next.js failing to fetch Google Fonts (`Inter` / `Outfit`) during the Turbopack step, which is an external network/font fetch issue and not caused by the application logic changes (code compiled up until the external font fetch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c82beac88321b7ed25571088d793)