### PR TITLE
Remove remote Google Fonts to fix offline Codex build

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -54,6 +54,9 @@
       radial-gradient(circle at 80% 12%, rgba(217, 70, 239, 0.16), transparent 30%),
       linear-gradient(180deg, #0b1120 0%, #131b33 50%, #0b1020 100%);
 
+    --font-inter: "Inter", "Avenir Next", "Segoe UI", sans-serif;
+    --font-outfit: "Outfit", "Avenir Next", "Segoe UI", sans-serif;
+
     /* Semantic Tokens */
     --surface-sunken: rgba(15, 23, 42, 0.72);
     --surface-raised: rgba(30, 41, 59, 0.72);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,9 @@
 // app/layout.tsx
 import type { Metadata } from 'next';
-import { Inter, Outfit } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Header } from '@/components/header';
 import { Toaster } from '@/components/ui/sonner';
-
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
-const outfit = Outfit({ subsets: ['latin'], variable: '--font-outfit' });
 
 export const metadata: Metadata = {
   title: 'ItsAllFunAndGames',
@@ -19,7 +15,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html
       lang="en"
       suppressHydrationWarning
-      className={`${inter.variable} ${outfit.variable}`}
     >
       <body className="min-h-screen bg-background text-foreground antialiased">
         <ThemeProvider


### PR DESCRIPTION
### Motivation
- The Next.js `next/font/google` usage attempted to fetch CSS from `fonts.googleapis.com` during `next build`, which caused builds to fail in offline/blocked environments.
- Provide stable typography fallbacks without introducing network dependencies so local builds (Codex) can complete reliably.

### Description
- Removed the `next/font/google` import and font initialization from `app/layout.tsx` and stopped injecting font variable classes into the `<html>` element.
- Added local fallback font stacks as CSS variables (`--font-inter` and `--font-outfit`) in `app/globals.css` so existing `var(--font-*)` usages continue to work.
- No other UI or layout markup was changed; the change only replaces runtime font fetching with local CSS fallbacks.

### Testing
- Ran `npm run build` and the build completes successfully after the change (previously failed due to Google Fonts fetch errors).
- Ran `npm run lint` which completes with the same pre-existing warnings (2 warnings, 0 errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ca3b46f08321aa6ab8b9e7ebffb5)