### PR TITLE
Add subtle 3D hover tilt effect to game cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -136,3 +136,69 @@
     @apply !transition-none !animate-none;
   }
 }
+
+@layer components {
+  .game-card-3d {
+    position: relative;
+    transform-style: preserve-3d;
+    perspective: 1200px;
+    transform: perspective(1200px) rotateX(var(--rotate-x, 0deg)) rotateY(var(--rotate-y, 0deg)) translateY(0) scale(1);
+    box-shadow: 0 12px 24px rgb(2 6 23 / 0.26);
+    transition: transform 240ms ease, box-shadow 240ms ease, border-color 240ms ease;
+    will-change: transform;
+  }
+
+  .game-card-3d::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    opacity: 0;
+    background: radial-gradient(circle at var(--glare-x, 50%) var(--glare-y, 50%), rgb(255 255 255 / 0.22), rgb(255 255 255 / 0) 45%);
+    transition: opacity 240ms ease;
+    z-index: 2;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .game-card-3d:hover {
+      transform: perspective(1200px) rotateX(var(--rotate-x, 0deg)) rotateY(var(--rotate-y, 0deg)) translateY(-6px) scale(1.01);
+      box-shadow: 0 22px 40px rgb(2 6 23 / 0.36);
+      border-color: rgb(163 230 53 / 0.45);
+    }
+
+    .game-card-3d:hover::before {
+      opacity: 1;
+    }
+  }
+
+  .game-card-3d:focus-within {
+    transform: perspective(1200px) rotateX(0deg) rotateY(0deg) translateY(-4px) scale(1.005);
+    box-shadow: 0 0 0 1px rgb(163 230 53 / 0.5), 0 18px 36px rgb(2 6 23 / 0.36);
+  }
+
+  @media (hover: none), (pointer: coarse) {
+    .game-card-3d {
+      transform: none;
+    }
+
+    .game-card-3d:active {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 28px rgb(2 6 23 / 0.32);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .game-card-3d,
+    .game-card-3d:hover,
+    .game-card-3d:focus-within,
+    .game-card-3d:active {
+      transform: none;
+      box-shadow: 0 12px 24px rgb(2 6 23 / 0.26);
+    }
+
+    .game-card-3d::before {
+      display: none;
+    }
+  }
+}

--- a/components/game/game-card.tsx
+++ b/components/game/game-card.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { prettifyFilterValue } from "@/lib/utils";
 import { Bookmark, BookmarkCheck } from "lucide-react";
 import Link from "next/link";
+import type { CSSProperties, PointerEvent } from "react";
 
 interface GameCardProps {
   game: Game;
@@ -23,6 +24,38 @@ const toRange = (min?: number | null, max?: number | null) => {
 };
 
 export function GameCard({ game, isBookmarked, onToggleBookmark, onTagToggle, activeTags }: GameCardProps) {
+  const card3dStyle = {
+    "--rotate-x": "0deg",
+    "--rotate-y": "0deg",
+    "--glare-x": "50%",
+    "--glare-y": "50%",
+  } as CSSProperties;
+
+  const handlePointerMove = (event: PointerEvent<HTMLElement>) => {
+    if (event.pointerType !== "mouse") return;
+
+    const card = event.currentTarget;
+    const rect = card.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const px = x / rect.width;
+    const py = y / rect.height;
+    const rotateX = (0.5 - py) * 8;
+    const rotateY = (px - 0.5) * 8;
+
+    card.style.setProperty("--rotate-x", `${rotateX.toFixed(2)}deg`);
+    card.style.setProperty("--rotate-y", `${rotateY.toFixed(2)}deg`);
+    card.style.setProperty("--glare-x", `${(px * 100).toFixed(1)}%`);
+    card.style.setProperty("--glare-y", `${(py * 100).toFixed(1)}%`);
+  };
+
+  const resetPointerState = (card: HTMLElement) => {
+    card.style.setProperty("--rotate-x", "0deg");
+    card.style.setProperty("--rotate-y", "0deg");
+    card.style.setProperty("--glare-x", "50%");
+    card.style.setProperty("--glare-y", "50%");
+  };
+
   const imageSrc = (() => {
     if (!game.image) return null;
     if (game.image.startsWith("http://") || game.image.startsWith("https://")) {
@@ -50,7 +83,17 @@ export function GameCard({ game, isBookmarked, onToggleBookmark, onTagToggle, ac
   ].filter(Boolean) as { label: string; value: string; rawValue?: string }[];
 
   return (
-    <Card className="overflow-hidden rounded-3xl border border-brand-sprout/25 bg-surface-raised shadow-md transition hover:-translate-y-1 hover:shadow-xl">
+    <Card
+      style={card3dStyle}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={(event) => resetPointerState(event.currentTarget)}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          resetPointerState(event.currentTarget);
+        }
+      }}
+      className="game-card-3d overflow-hidden rounded-3xl border border-brand-sprout/25 bg-surface-raised"
+    >
       <div className="relative aspect-[16/9] w-full overflow-hidden bg-gradient-to-br from-brand-sprout/15 via-brand-marigold/15 to-brand-coral/20">
         {imageSrc ? (
           <Image src={imageSrc} alt={game.name} fill className="object-cover" />


### PR DESCRIPTION
### Motivation
- Improve the perceived quality and interactivity of game/activity cards by adding a subtle 3D tilt, depth and highlight on pointer hover while keeping the UI tasteful and readable.
- Ensure the effect is accessible and non-disruptive by providing keyboard focus styling, respecting `prefers-reduced-motion`, and keeping mobile/touch behavior stable.

### Description
- Added reusable `.game-card-3d` component styles in `app/globals.css` including `perspective`, `transform` driven by CSS variables (`--rotate-x`, `--rotate-y`, `--glare-x`, `--glare-y`), a moving glare pseudo-element, hover lift, shadow depth, and media-query fallbacks for coarse pointers and reduced motion.
- Updated `components/game/game-card.tsx` to initialize CSS variables via a `style` prop and wire a small, isolated pointer tracker that updates those variables on `onPointerMove` and resets them on `onPointerLeave`/`onBlur`, while leaving bookmark, tag, and link handlers untouched.
- Kept the implementation dependency-free and lightweight by using native CSS transforms and a compact React pointer handler; no new packages were introduced.
- Files changed: `components/game/game-card.tsx` and `app/globals.css`.

### Testing
- Ran `npm run lint`, which completed successfully and shows two pre-existing warnings unrelated to this change.
- Ran `npm run build`, which completed successfully (includes the same pre-existing lint warnings) and produced a successful production build with no build errors.
- Observed that bookmark, tag clicks, and navigation remained functional during local verification; no console errors appeared during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ef43d2988321abd0858fa0ea199f)