### PR TITLE
Redesign front page with Vivid Play glassmorphism styling

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,3 @@
-// app/layout.tsx
 import type { Metadata } from 'next';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
@@ -12,29 +11,17 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html
-      lang="en"
-      suppressHydrationWarning
-    >
-      <body className="min-h-screen bg-background text-foreground antialiased">
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen bg-[#0c1324] text-[#dce1fb] antialiased">
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme="dark"
           enableSystem
           disableTransitionOnChange
           storageKey="itsallfunandgames-theme"
         >
           <Header />
-          <main className="container mx-auto max-w-6xl px-4 py-10">
-            <div
-              className="relative z-0 overflow-hidden rounded-[2.75rem] border border-white/60 bg-white/80 p-6 shadow-[0_20px_60px_rgba(15,23,42,0.12)] ring-1 ring-black/5 backdrop-blur supports-[backdrop-filter]:bg-white/65 dark:border-white/10 dark:bg-slate-950/70 dark:ring-white/5 md:p-10"
-            >
-              <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-emerald-200/40 via-transparent to-rose-200/50 dark:from-emerald-400/10 dark:via-transparent dark:to-rose-500/20" />
-              {children}
-            </div>
-          </main>
-
-          {/* Toasts (Sonner via shadcn wrapper) */}
+          <main className="mx-auto w-full max-w-[1280px] px-4 py-8 md:px-8 md:py-12">{children}</main>
           <Toaster richColors position="top-right" duration={3000} />
         </ThemeProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,9 @@
-// app/page.tsx
 import { games } from '@/lib/loadGames';
 import { GameClient } from './game-client';
 import { Game } from '@/lib/types';
 import { Suspense } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 
-// Helper to get unique facet values
 const getUniqueValues = (games: Game[], key: keyof Game) => {
   const values = new Set<string>();
   games.forEach(game => {
@@ -42,19 +40,29 @@ export default function HomePage() {
   };
 
   return (
-    <section className="relative z-10 space-y-12 sm:space-y-16">
-      <div className="mx-auto max-w-3xl text-center">
-        <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-cyan-300/40 bg-cyan-400/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-cyan-200 shadow-sm">
-          <span aria-hidden="true">🎲</span>
-          Game inspiration
-        </span>
-        <h1 className="bg-gradient-to-r from-cyan-200 via-sky-100 to-fuchsia-200 bg-clip-text text-4xl font-black tracking-tight text-transparent sm:text-5xl lg:text-6xl">
-          Find Your Next Favourite Game
-        </h1>
-        <p className="mt-4 text-lg text-slate-300 sm:text-xl">
-          Browse curated activities, mix and match filters, and plan unforgettable play sessions for any group, age, or space.
-        </p>
+    <section className="space-y-12 md:space-y-16">
+      <div className="relative overflow-hidden rounded-[28px] border border-[#1E293B] bg-gradient-to-br from-[#2e3447]/80 to-[#151b2d]/90 p-6 md:p-12">
+        <div className="pointer-events-none absolute -right-32 -top-36 h-80 w-80 rounded-full bg-[#f0abfc]/20 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-28 -left-28 h-80 w-80 rounded-full bg-[#02aebe]/20 blur-3xl" />
+        <div className="relative max-w-3xl rounded-2xl border border-[#1E293B] bg-[#0f172a]/60 p-6 backdrop-blur-xl md:p-10">
+          <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#1E293B] bg-[#23293c]/70 px-4 py-1 text-sm font-semibold text-[#d1c2cf]">
+            🎲 Game inspiration
+          </span>
+          <h1 className="font-heading text-4xl font-extrabold tracking-tight text-[#dce1fb] md:text-6xl">Find Your Next Favourite Game</h1>
+          <p className="mt-4 text-lg text-[#94A3B8]">
+            Browse curated activities, filter in seconds, and plan unforgettable sessions for any group, age, or space.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <button className="rounded-full bg-[#f0abfc] px-6 py-3 text-sm font-semibold text-black transition hover:shadow-[0_0_24px_rgba(240,171,252,0.5)] active:scale-95">
+              Explore Collection
+            </button>
+            <button className="rounded-full border-2 border-[#54d8e8] px-6 py-3 text-sm font-semibold text-[#54d8e8] transition hover:bg-[#54d8e8]/10 active:scale-95">
+              Surprise Me
+            </button>
+          </div>
+        </div>
       </div>
+
       <Suspense
         fallback={
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -66,6 +74,13 @@ export default function HomePage() {
       >
         <GameClient allGames={sortedGames} facets={facets} />
       </Suspense>
+
+      <footer className="rounded-3xl border border-[#1E293B] bg-[#070d1f] px-6 py-10 text-[#94A3B8] md:px-10">
+        <div className="flex flex-col items-start justify-between gap-6 md:flex-row md:items-center">
+          <p className="font-heading text-xl font-bold text-[#fbd2ff]">itsallfunandgames</p>
+          <p className="text-sm">© 2026 Itsallfunandgames. All play, no work.</p>
+        </div>
+      </footer>
     </section>
   );
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,36 +1,39 @@
-// components/header.tsx
 'use client';
+
 import Link from 'next/link';
+import { Bell, Menu, Moon, Sun, UserCircle2 } from 'lucide-react';
 import { useTheme } from 'next-themes';
-import { Button } from './ui/button';
-import { Moon, Sun } from 'lucide-react';
 
 export function Header() {
   const { setTheme, theme } = useTheme();
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-cyan-400/20 bg-slate-950/75 backdrop-blur-xl supports-[backdrop-filter]:bg-slate-950/65">
-      <div className="container flex h-16 items-center justify-between">
-        <Link
-          href="/"
-          className="font-heading text-2xl font-bold tracking-tight text-cyan-300 transition-colors hover:text-fuchsia-300"
-        >
-          itsallfunandgames
-        </Link>
-        <nav className="flex items-center gap-6 text-sm font-medium text-slate-200">
-          <Link href="/data/quality" className="transition-colors hover:text-cyan-300">
-            Diagnostics
+    <header className="sticky top-0 z-50 border-b border-[#1E293B] bg-[#0c1324]/80 backdrop-blur-xl">
+      <div className="mx-auto flex h-16 w-full max-w-[1280px] items-center justify-between px-4 md:px-8">
+        <div className="flex items-center gap-8">
+          <Link href="/" className="font-heading text-xl font-extrabold tracking-tight text-[#fbd2ff] md:text-2xl">
+            itsallfunandgames
           </Link>
-          <Button
-            variant="ghost"
-            size="icon"
+          <nav className="hidden items-center gap-5 text-sm text-[#d1c2cf] md:flex">
+            <Link href="/" className="border-b-2 border-[#fbd2ff] pb-1 font-semibold text-[#fbd2ff]">Discover</Link>
+            <Link href="/data/quality" className="transition-colors hover:text-[#dce1fb]">Diagnostics</Link>
+          </nav>
+        </div>
+
+        <div className="flex items-center gap-2 md:gap-3">
+          <button
+            type="button"
             onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
             aria-label="Toggle theme"
+            className="rounded-full p-2 text-[#fbd2ff] transition hover:bg-white/10"
           >
-            <Sun className="h-5 w-5 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
-            <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />
-          </Button>
-        </nav>
+            <Sun className="h-4 w-4 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
+            <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />
+          </button>
+          <button type="button" className="hidden rounded-full p-2 text-[#fbd2ff] transition hover:bg-white/10 md:inline-flex"><Bell className="h-4 w-4" /></button>
+          <button type="button" className="hidden rounded-full p-2 text-[#fbd2ff] transition hover:bg-white/10 md:inline-flex"><UserCircle2 className="h-4 w-4" /></button>
+          <button type="button" className="inline-flex rounded-full p-2 text-[#fbd2ff] transition hover:bg-white/10 md:hidden"><Menu className="h-4 w-4" /></button>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
### Motivation
- Refresh the landing experience to the new "Vivid Play" visual system with a cinematic dark glassmorphism look and stronger brand emphasis.
- Surface a more tactile, discovery-first hero and navigation so game discovery feels modern and approachable.

### Description
- Updated the global shell in `app/layout.tsx` to use a dark default theme, set the page background to `#0c1324`, and adjust the main container width/spacing to match the new visual system.
- Reworked the homepage in `app/page.tsx` to render a glassmorphic hero with layered glow gradients, a centered glass card, redesigned headline and dual CTAs, and an added branded footer while keeping the existing `GameClient` integration.
- Restyled the top navigation in `components/header.tsx` with Vivid Play colors, compact icons, responsive layout tweaks, and a theme toggle that defaults to the dark theme.
- Adjusted Tailwind utility classes and color tokens in the UI so the hero, CTAs, nav, and footer align with the Vivid Play palette and spacing rules.

### Testing
- Ran `npm run lint` and it completed successfully with two pre-existing warnings in unrelated files and no errors.
- Attempted a visual verification with Playwright (`npx playwright screenshot`) but the run could not complete because `npx playwright install chromium` failed due to a browser download `HTTP 403` in this environment, so screenshots were not captured.
- No unit or end-to-end tests were executed as part of this rollout beyond linting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08577b0af48321b2a29d881a12a49e)