### PR TITLE
Remove sidebar filter UI and related controls

### DIFF
--- a/app/game-client.tsx
+++ b/app/game-client.tsx
@@ -10,17 +10,7 @@ import {
 import { useEffect, useMemo, useState, useRef, type FormEvent } from "react";
 import { useDebounce } from "use-debounce";
 import Fuse from "fuse.js";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Filter,
-  PanelLeftClose,
-  PanelLeftOpen,
-  X,
-} from "lucide-react";
-import { prettifyFilterValue } from "@/lib/utils";
-import { FacetKey, facetKeys, filterMeta } from "@/lib/constants";
-import { FilterSidebar } from "@/components/game/filter-sidebar";
 import { SearchBar } from "@/components/game/search-bar";
 import { GameGrid } from "@/components/game/game-grid";
 import { PaginationControl } from "@/components/game/pagination-control";
@@ -32,42 +22,18 @@ const fuseOptions = {
   threshold: 0.4,
 };
 
-type Facets = Record<FacetKey, string[]>;
-
 type FiltersState = {
   query: string;
   page: number;
   bookmarkedOnly: boolean;
-} & {
-  [K in FacetKey]: string[];
 };
 
 const DEFAULT_PAGE = 1;
-const toRange = (min?: number | null, max?: number | null) => {
-  if (typeof min === "number" && typeof max === "number") return `${min}–${max}`;
-  if (typeof min === "number") return `${min}+`;
-  if (typeof max === "number") return `Up to ${max}`;
-  return null;
-};
-
-const createEmptySelections = (): Record<FacetKey, string[]> =>
-  facetKeys.reduce((acc, key) => {
-    acc[key] = [];
-    return acc;
-  }, {} as Record<FacetKey, string[]>);
-
 const createDefaultFilters = (): FiltersState => ({
   query: "",
   page: DEFAULT_PAGE,
   bookmarkedOnly: false,
-  ...createEmptySelections(),
 });
-
-const createEmptySearches = (): Record<FacetKey, string> =>
-  facetKeys.reduce((acc, key) => {
-    acc[key] = "";
-    return acc;
-  }, {} as Record<FacetKey, string>);
 
 const parsePageParam = (value: string | null) => {
   if (!value) {
@@ -88,37 +54,17 @@ const buildFiltersFromParams = (
   next.page = parsePageParam(params.get("page"));
   next.bookmarkedOnly = params.get("bookmarked") === "1";
 
-  facetKeys.forEach((key) => {
-    const values = params
-      .getAll(key)
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0);
-    if (values.length > 0) {
-      next[key] = Array.from(new Set(values)).sort((a, b) =>
-        a.localeCompare(b)
-      );
-    }
-  });
 
   return next;
 };
 
-const arraysEqual = (a: string[], b: string[]) => {
-  if (a.length !== b.length) return false;
-  return a.every((value, index) => value === b[index]);
-};
-
-const areFiltersEqual = (a: FiltersState, b: FiltersState) => {
-  if (a.query !== b.query || a.page !== b.page || a.bookmarkedOnly !== b.bookmarkedOnly) return false;
-  return facetKeys.every((key) => arraysEqual(a[key], b[key]));
-};
+const areFiltersEqual = (a: FiltersState, b: FiltersState) =>
+  a.query === b.query && a.page === b.page && a.bookmarkedOnly === b.bookmarkedOnly;
 
 export function GameClient({
   allGames,
-  facets,
 }: {
   allGames: Game[];
-  facets: Facets;
 }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -130,24 +76,8 @@ export function GameClient({
   const [filters, setFilters] = useState<FiltersState>(() =>
     buildFiltersFromParams(searchParams)
   );
-  const [filterSearches, setFilterSearches] = useState<Record<FacetKey, string>>(
-    () => createEmptySearches()
-  );
   const [isSearchFocused, setIsSearchFocused] = useState(false);
-  const [isFilterRailCollapsed, setIsFilterRailCollapsed] = useState(false);
-  const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
-  const [pendingScrollKey, setPendingScrollKey] = useState<FacetKey | null>(
-    null
-  );
-  const closeFilterSheet = () => setIsFilterSheetOpen(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const initialExpandedFiltersRef = useRef<FacetKey[] | null>(null);
-
-  if (initialExpandedFiltersRef.current === null) {
-    initialExpandedFiltersRef.current = facetKeys.filter(
-      (key) => filters[key].length > 0
-    );
-  }
 
   const [debouncedQuery] = useDebounce(filters.query, 300);
   const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set());
@@ -160,56 +90,9 @@ export function GameClient({
 
     return searchResults.filter((game) => {
       if (filters.bookmarkedOnly && !bookmarkedIds.has(game.id)) return false;
-      const {
-        category: selectedCategories,
-        tags: selectedTags,
-        prepLevel: selectedPrepLevels,
-        playersRange: selectedPlayers,
-        ageRange: selectedAges,
-        equipmentNeeded: selectedEquipment,
-        skillsDeveloped: selectedSkills,
-      } = filters;
 
-      if (
-        selectedCategories.length > 0 &&
-        (!game.category || !selectedCategories.includes(game.category))
-      ) {
-        return false;
-      }
 
-      if (
-        selectedTags.length > 0 &&
-        !(game.tags || []).some((tag) => selectedTags.includes(tag))
-      ) {
-        return false;
-      }
 
-      if (
-        selectedPrepLevels.length > 0 &&
-        (!game.prepLevel || !selectedPrepLevels.includes(game.prepLevel))
-      ) {
-        return false;
-      }
-      const playersRange = toRange(game.playersMin, game.playersMax);
-      if (selectedPlayers.length > 0 && (!playersRange || !selectedPlayers.includes(playersRange))) {
-        return false;
-      }
-      const ageRange = toRange(game.ageMin, game.ageMax);
-      if (selectedAges.length > 0 && (!ageRange || !selectedAges.includes(ageRange))) {
-        return false;
-      }
-      if (selectedEquipment.length > 0 && !game.equipment) {
-        return false;
-      }
-
-      if (
-        selectedSkills.length > 0 &&
-        !(game.skillsDeveloped || []).some((skill) =>
-          selectedSkills.includes(skill)
-        )
-      ) {
-        return false;
-      }
 
       return true;
     });
@@ -229,11 +112,6 @@ export function GameClient({
 
     if (filters.bookmarkedOnly) params.set("bookmarked", "1");
 
-    facetKeys.forEach((key) => {
-      filters[key].forEach((value) => {
-        params.append(key, value);
-      });
-    });
 
     if (currentPage > 1) params.set("page", String(currentPage));
 
@@ -255,63 +133,10 @@ export function GameClient({
     );
   }, [searchParams]);
 
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    if (window.innerWidth < 1024) {
-      setIsFilterRailCollapsed(true);
-    }
-    const handleResize = () => {
-      if (window.innerWidth >= 1024) {
-        setIsFilterRailCollapsed(false);
-      }
-    };
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
 
-  useEffect(() => {
-    if (!isFilterSheetOpen) {
-      return;
-    }
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = originalOverflow;
-    };
-  }, [isFilterSheetOpen]);
 
-  useEffect(() => {
-    if (!isFilterSheetOpen || !pendingScrollKey) {
-      return;
-    }
-    const element = document.getElementById(`filter-group-${pendingScrollKey}`);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "start" });
-      setPendingScrollKey(null);
-    }
-  }, [isFilterSheetOpen, pendingScrollKey]);
 
-  const updateFilterValue = (key: FacetKey, value: string, include: boolean) => {
-    setFilters((prev) => {
-      const hasValue = prev[key].includes(value);
-      if (include && hasValue) return prev;
-      if (!include && !hasValue) return prev;
-      const nextValues = include
-        ? [...prev[key], value].sort((a, b) => a.localeCompare(b))
-        : prev[key].filter((v) => v !== value);
-      return { ...prev, [key]: nextValues, page: DEFAULT_PAGE };
-    });
-  };
 
-  const clearFilterGroup = (key: FacetKey) => {
-    setFilters((prev) => {
-      if (prev[key].length === 0) return prev;
-      return { ...prev, [key]: [], page: DEFAULT_PAGE };
-    });
-    setFilterSearches((prev) => ({ ...prev, [key]: "" }));
-  };
 
   useEffect(() => {
     const stored = window.localStorage.getItem("iafg-bookmarks");
@@ -333,7 +158,6 @@ export function GameClient({
 
   const resetFilters = () => {
     setFilters(createDefaultFilters());
-    setFilterSearches(createEmptySearches());
   };
 
   const handlePageChange = (page: number) => {
@@ -350,28 +174,17 @@ export function GameClient({
 
   const showSuggestions = isSearchFocused && suggestions.length > 0;
 
-  const activeFilters = useMemo(
-    () =>
-      facetKeys.flatMap((key) =>
-        filters[key].map((value) => ({ key, value }))
-      ),
-    [filters]
-  );
-
-  const hasActiveFilters = activeFilters.length > 0;
 
   const trimmedQuery = filters.query.trim();
   const resultsCount = filteredGames.length;
   const heading =
     trimmedQuery.length > 0
       ? `Results for “${trimmedQuery}` + "”"
-      : hasActiveFilters
-        ? "Showing filtered games"
-        : "Showing all games";
+      : "Showing all games";
   const resultsSummary =
     resultsCount === 0
       ? "No games match your current filters."
-      : `${resultsCount} game${resultsCount === 1 ? "" : "s"} ${trimmedQuery.length > 0 || hasActiveFilters
+      : `${resultsCount} game${resultsCount === 1 ? "" : "s"} ${trimmedQuery.length > 0
         ? "matching your criteria"
         : "ready to explore"
       }`;
@@ -395,53 +208,12 @@ export function GameClient({
     inputRef.current?.blur();
   };
 
-  const openFilterSheet = (key?: FacetKey) => {
-    if (key) {
-      setPendingScrollKey(key);
-    }
-    setIsFilterSheetOpen(true);
-  };
 
   return (
     <div className="relative min-h-screen bg-surface-sunken text-text-brand">
       <div className="mx-auto flex max-w-7xl flex-wrap gap-6 px-4 py-10 lg:flex-nowrap lg:gap-10">
-        <FilterSidebar
-          filters={filters}
-          facets={facets}
-          filterSearches={filterSearches}
-          setFilterSearches={setFilterSearches}
-          isFilterRailCollapsed={isFilterRailCollapsed}
-          setIsFilterRailCollapsed={setIsFilterRailCollapsed}
-          isFilterSheetOpen={isFilterSheetOpen}
-          closeFilterSheet={closeFilterSheet}
-          resetFilters={resetFilters}
-          updateFilterValue={updateFilterValue}
-          clearFilterGroup={clearFilterGroup}
-          openFilterSheet={openFilterSheet}
-          initialExpandedFilters={initialExpandedFiltersRef.current ?? []}
-        />
-
         <main className="flex min-w-0 flex-1 flex-col gap-8">
           <header className="flex flex-wrap items-center gap-3 rounded-3xl border border-brand-sprout/20 bg-surface-raised p-4 shadow-sm backdrop-blur">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-10 w-10 rounded-full bg-surface-highlight text-text-brand hover:bg-brand-sprout/20"
-              onClick={() => setIsFilterRailCollapsed((prev) => !prev)}
-              aria-label={
-                isFilterRailCollapsed
-                  ? "Expand filter navigation"
-                  : "Collapse filter navigation"
-              }
-            >
-              {isFilterRailCollapsed ? (
-                <PanelLeftOpen className="h-5 w-5" />
-              ) : (
-                <PanelLeftClose className="h-5 w-5" />
-              )}
-            </Button>
-
             <SearchBar
               query={filters.query}
               setQuery={(q) => setFilters(prev => ({ ...prev, query: q, page: DEFAULT_PAGE }))}
@@ -454,20 +226,6 @@ export function GameClient({
               inputRef={inputRef}
             />
 
-            <Button
-              type="button"
-              variant="outline"
-              className="inline-flex flex-shrink-0 items-center gap-2 rounded-full border-brand-sprout/40 bg-white px-4 py-2 text-sm font-semibold text-text-brand hover:bg-brand-sprout/10 focus-visible:ring-brand-marigold"
-              onClick={() => openFilterSheet()}
-            >
-              <Filter className="h-4 w-4 text-brand-sprout" />
-              Filters
-              {hasActiveFilters && (
-                <Badge className="ml-1 rounded-full bg-surface-highlight px-2 py-1 text-[11px] font-semibold text-brand-sprout">
-                  {activeFilters.length}
-                </Badge>
-              )}
-            </Button>
           </header>
 
           <div className="rounded-3xl border border-brand-sprout/20 bg-surface-raised/90 p-6 shadow-sm backdrop-blur">
@@ -483,55 +241,14 @@ export function GameClient({
             <p className="mt-4 max-w-2xl text-sm leading-6 text-text-brand/75">
               Discover activities that spark connection, collaboration, and laughs for every group size.
             </p>
-            <p className="mt-2 text-sm text-text-brand/60">
-              Use the menu button to collapse the filter rail or tap “Filters” to open it as a sheet.
-            </p>
           </div>
 
-          {hasActiveFilters && (
-            <div className="flex flex-wrap items-center gap-2 rounded-3xl border border-brand-sprout/20 bg-surface-raised/90 p-4 shadow-sm backdrop-blur">
-              <span className="text-sm font-medium text-text-brand/80">Active filters:</span>
-              {activeFilters.map(({ key, value }) => {
-                const label = filterMeta[key].label;
-                return (
-                  <Badge
-                    key={`${key}-${value}`}
-                    variant="secondary"
-                    className="flex items-center gap-2 rounded-full bg-surface-highlight px-3 py-1 text-sm font-medium text-text-brand"
-                  >
-                    <span className="font-semibold text-brand-sprout">{label}:</span>
-                    <span>{prettifyFilterValue(value)}</span>
-                    <button
-                      type="button"
-                      className="rounded-full p-0.5 text-brand-sprout transition hover:bg-brand-sprout/20"
-                      onClick={() => updateFilterValue(key, value, false)}
-                    >
-                      <X className="h-3 w-3" />
-                      <span className="sr-only">Remove {prettifyFilterValue(value)}</span>
-                    </button>
-                  </Badge>
-                );
-              })}
-              <Button
-                variant="ghost"
-                size="sm"
-                className="ml-auto h-8 px-3 text-xs font-semibold text-brand-sprout hover:bg-surface-highlight"
-                onClick={resetFilters}
-              >
-                Clear all
-              </Button>
-            </div>
-          )}
 
           <GameGrid
             games={paginatedGames}
             resetFilters={resetFilters}
             bookmarkedIds={bookmarkedIds}
             onToggleBookmark={toggleBookmark}
-            onMetaToggle={updateFilterValue}
-            activeFilters={Object.fromEntries(
-              facetKeys.map((key) => [key, new Set(filters[key])])
-            )}
           />
 
           <PaginationControl

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,43 +1,14 @@
 import { games } from '@/lib/loadGames';
 import { GameClient } from './game-client';
-import { Game } from '@/lib/types';
 import { Suspense } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 
-const getUniqueValues = (games: Game[], key: keyof Game) => {
-  const values = new Set<string>();
-  games.forEach(game => {
-    const value = game[key];
-    if (typeof value === 'string' && value) {
-      values.add(value);
-    } else if (Array.isArray(value)) {
-      value.forEach(v => typeof v === 'string' && v && values.add(v));
-    }
-  });
-  return Array.from(values).sort();
-};
-
-const toRange = (min?: number | null, max?: number | null) => {
-  if (typeof min === 'number' && typeof max === 'number') return `${min}–${max}`;
-  if (typeof min === 'number') return `${min}+`;
-  if (typeof max === 'number') return `Up to ${max}`;
-  return null;
-};
 
 export default function HomePage() {
   const sortedGames = [...games].sort((a, b) =>
     a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
   );
 
-  const facets = {
-    category: getUniqueValues(sortedGames, 'category'),
-    tags: getUniqueValues(sortedGames, 'tags'),
-    prepLevel: getUniqueValues(sortedGames, 'prepLevel'),
-    playersRange: Array.from(new Set(sortedGames.map((g) => toRange(g.playersMin, g.playersMax)).filter(Boolean) as string[])).sort(),
-    ageRange: Array.from(new Set(sortedGames.map((g) => toRange(g.ageMin, g.ageMax)).filter(Boolean) as string[])).sort(),
-    equipmentNeeded: Array.from(new Set(sortedGames.map((g) => (g.equipment ? 'Equipment needed' : null)).filter(Boolean) as string[])).sort(),
-    skillsDeveloped: getUniqueValues(sortedGames, 'skillsDeveloped'),
-  };
 
   return (
     <section className="space-y-12 md:space-y-16">
@@ -72,7 +43,7 @@ export default function HomePage() {
           </div>
         }
       >
-        <GameClient allGames={sortedGames} facets={facets} />
+        <GameClient allGames={sortedGames} />
       </Suspense>
 
       <footer className="rounded-3xl border border-[#1E293B] bg-[#070d1f] px-6 py-10 text-[#94A3B8] md:px-10">


### PR DESCRIPTION
### Motivation
- The app no longer needs the per-facet sidebar filtering UX, so the sidebar and its associated controls were removed to simplify the browsing experience.
- URL sync should keep only the core state (search query, bookmarks toggle, and pagination) instead of many facet parameters.

### Description
- Removed `FilterSidebar` usage and all sidebar-related state, effects, and helpers from `app/game-client.tsx`, simplifying `GameClient` to manage only search, bookmarks, and pagination.
- Deleted header buttons and controls for collapsing/expanding the filter rail and opening the filter sheet, leaving only the search bar and bookmark toggle in the header.
- Removed facet parsing/serialization and per-facet filter logic (including active filter chips and remove buttons) so `filters` state no longer contains facet selections.
- Stopped computing and passing `facets` from `app/page.tsx` and updated the `GameClient` invocation to only pass `allGames`.

### Testing
- Ran `npm run lint` and it completed successfully; the output contains pre-existing warnings unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acb0e85148321af5edf37529038f8)