### PR TITLE
Simplify GameClient by removing facet filters and sidebar

### DIFF
--- a/app/game-client.tsx
+++ b/app/game-client.tsx
@@ -10,17 +10,7 @@ import {
 import { useEffect, useMemo, useState, useRef, type FormEvent } from "react";
 import { useDebounce } from "use-debounce";
 import Fuse from "fuse.js";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Filter,
-  PanelLeftClose,
-  PanelLeftOpen,
-  X,
-} from "lucide-react";
-import { prettifyFilterValue } from "@/lib/utils";
-import { FacetKey, facetKeys, filterMeta } from "@/lib/constants";
-import { FilterSidebar } from "@/components/game/filter-sidebar";
 import { SearchBar } from "@/components/game/search-bar";
 import { GameGrid } from "@/components/game/game-grid";
 import { PaginationControl } from "@/components/game/pagination-control";
@@ -32,42 +22,18 @@ const fuseOptions = {
   threshold: 0.4,
 };
 
-type Facets = Record<FacetKey, string[]>;
-
 type FiltersState = {
   query: string;
   page: number;
   bookmarkedOnly: boolean;
-} & {
-  [K in FacetKey]: string[];
 };
 
 const DEFAULT_PAGE = 1;
-const toRange = (min?: number | null, max?: number | null) => {
-  if (typeof min === "number" && typeof max === "number") return `${min}–${max}`;
-  if (typeof min === "number") return `${min}+`;
-  if (typeof max === "number") return `Up to ${max}`;
-  return null;
-};
-
-const createEmptySelections = (): Record<FacetKey, string[]> =>
-  facetKeys.reduce((acc, key) => {
-    acc[key] = [];
-    return acc;
-  }, {} as Record<FacetKey, string[]>);
-
 const createDefaultFilters = (): FiltersState => ({
   query: "",
   page: DEFAULT_PAGE,
   bookmarkedOnly: false,
-  ...createEmptySelections(),
 });
-
-const createEmptySearches = (): Record<FacetKey, string> =>
-  facetKeys.reduce((acc, key) => {
-    acc[key] = "";
-    return acc;
-  }, {} as Record<FacetKey, string>);
 
 const parsePageParam = (value: string | null) => {
   if (!value) {
@@ -88,37 +54,17 @@ const buildFiltersFromParams = (
   next.page = parsePageParam(params.get("page"));
   next.bookmarkedOnly = params.get("bookmarked") === "1";
 
-  facetKeys.forEach((key) => {
-    const values = params
-      .getAll(key)
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0);
-    if (values.length > 0) {
-      next[key] = Array.from(new Set(values)).sort((a, b) =>
-        a.localeCompare(b)
-      );
-    }
-  });
 
   return next;
 };
 
-const arraysEqual = (a: string[], b: string[]) => {
-  if (a.length !== b.length) return false;
-  return a.every((value, index) => value === b[index]);
-};
-
-const areFiltersEqual = (a: FiltersState, b: FiltersState) => {
-  if (a.query !== b.query || a.page !== b.page || a.bookmarkedOnly !== b.bookmarkedOnly) return false;
-  return facetKeys.every((key) => arraysEqual(a[key], b[key]));
-};
+const areFiltersEqual = (a: FiltersState, b: FiltersState) =>
+  a.query === b.query && a.page === b.page && a.bookmarkedOnly === b.bookmarkedOnly;
 
 export function GameClient({
   allGames,
-  facets,
 }: {
   allGames: Game[];
-  facets: Facets;
 }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -130,24 +76,8 @@ export function GameClient({
   const [filters, setFilters] = useState<FiltersState>(() =>
     buildFiltersFromParams(searchParams)
   );
-  const [filterSearches, setFilterSearches] = useState<Record<FacetKey, string>>(
-    () => createEmptySearches()
-  );
   const [isSearchFocused, setIsSearchFocused] = useState(false);
-  const [isFilterRailCollapsed, setIsFilterRailCollapsed] = useState(false);
-  const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
-  const [pendingScrollKey, setPendingScrollKey] = useState<FacetKey | null>(
-    null
-  );
-  const closeFilterSheet = () => setIsFilterSheetOpen(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const initialExpandedFiltersRef = useRef<FacetKey[] | null>(null);
-
-  if (initialExpandedFiltersRef.current === null) {
-    initialExpandedFiltersRef.current = facetKeys.filter(
-      (key) => filters[key].length > 0
-    );
-  }
 
   const [debouncedQuery] = useDebounce(filters.query, 300);
   const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set());
@@ -160,56 +90,9 @@ export function GameClient({
 
     return searchResults.filter((game) => {
       if (filters.bookmarkedOnly && !bookmarkedIds.has(game.id)) return false;
-      const {
-        category: selectedCategories,
-        tags: selectedTags,
-        prepLevel: selectedPrepLevels,
-        playersRange: selectedPlayers,
-        ageRange: selectedAges,
-        equipmentNeeded: selectedEquipment,
-        skillsDeveloped: selectedSkills,
-      } = filters;
 
-      if (
-        selectedCategories.length > 0 &&
-        (!game.category || !selectedCategories.includes(game.category))
-      ) {
-        return false;
-      }
 
-      if (
-        selectedTags.length > 0 &&
-        !(game.tags || []).some((tag) => selectedTags.includes(tag))
-      ) {
-        return false;
-      }
 
-      if (
-        selectedPrepLevels.length > 0 &&
-        (!game.prepLevel || !selectedPrepLevels.includes(game.prepLevel))
-      ) {
-        return false;
-      }
-      const playersRange = toRange(game.playersMin, game.playersMax);
-      if (selectedPlayers.length > 0 && (!playersRange || !selectedPlayers.includes(playersRange))) {
-        return false;
-      }
-      const ageRange = toRange(game.ageMin, game.ageMax);
-      if (selectedAges.length > 0 && (!ageRange || !selectedAges.includes(ageRange))) {
-        return false;
-      }
-      if (selectedEquipment.length > 0 && !game.equipment) {
-        return false;
-      }
-
-      if (
-        selectedSkills.length > 0 &&
-        !(game.skillsDeveloped || []).some((skill) =>
-          selectedSkills.includes(skill)
-        )
-      ) {
-        return false;
-      }
 
       return true;
     });
@@ -229,11 +112,6 @@ export function GameClient({
 
     if (filters.bookmarkedOnly) params.set("bookmarked", "1");
 
-    facetKeys.forEach((key) => {
-      filters[key].forEach((value) => {
-        params.append(key, value);
-      });
-    });
 
     if (currentPage > 1) params.set("page", String(currentPage));
 
@@ -255,63 +133,10 @@ export function GameClient({
     );
   }, [searchParams]);
 
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    if (window.innerWidth < 1024) {
-      setIsFilterRailCollapsed(true);
-    }
-    const handleResize = () => {
-      if (window.innerWidth >= 1024) {
-        setIsFilterRailCollapsed(false);
-      }
-    };
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
 
-  useEffect(() => {
-    if (!isFilterSheetOpen) {
-      return;
-    }
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = originalOverflow;
-    };
-  }, [isFilterSheetOpen]);
 
-  useEffect(() => {
-    if (!isFilterSheetOpen || !pendingScrollKey) {
-      return;
-    }
-    const element = document.getElementById(`filter-group-${pendingScrollKey}`);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "start" });
-      setPendingScrollKey(null);
-    }
-  }, [isFilterSheetOpen, pendingScrollKey]);
 
-  const updateFilterValue = (key: FacetKey, value: string, include: boolean) => {
-    setFilters((prev) => {
-      const hasValue = prev[key].includes(value);
-      if (include && hasValue) return prev;
-      if (!include && !hasValue) return prev;
-      const nextValues = include
-        ? [...prev[key], value].sort((a, b) => a.localeCompare(b))
-        : prev[key].filter((v) => v !== value);
-      return { ...prev, [key]: nextValues, page: DEFAULT_PAGE };
-    });
-  };
 
-  const clearFilterGroup = (key: FacetKey) => {
-    setFilters((prev) => {
-      if (prev[key].length === 0) return prev;
-      return { ...prev, [key]: [], page: DEFAULT_PAGE };
-    });
-    setFilterSearches((prev) => ({ ...prev, [key]: "" }));
-  };
 
   useEffect(() => {
     const stored = window.localStorage.getItem("iafg-bookmarks");
@@ -333,7 +158,6 @@ export function GameClient({
 
   const resetFilters = () => {
     setFilters(createDefaultFilters());
-    setFilterSearches(createEmptySearches());
   };
 
   const handlePageChange = (page: number) => {
@@ -350,28 +174,17 @@ export function GameClient({
 
   const showSuggestions = isSearchFocused && suggestions.length > 0;
 
-  const activeFilters = useMemo(
-    () =>
-      facetKeys.flatMap((key) =>
-        filters[key].map((value) => ({ key, value }))
-      ),
-    [filters]
-  );
-
-  const hasActiveFilters = activeFilters.length > 0;
 
   const trimmedQuery = filters.query.trim();
   const resultsCount = filteredGames.length;
   const heading =
     trimmedQuery.length > 0
       ? `Results for “${trimmedQuery}` + "”"
-      : hasActiveFilters
-        ? "Showing filtered games"
-        : "Showing all games";
+      : "Showing all games";
   const resultsSummary =
     resultsCount === 0
       ? "No games match your current filters."
-      : `${resultsCount} game${resultsCount === 1 ? "" : "s"} ${trimmedQuery.length > 0 || hasActiveFilters
+      : `${resultsCount} game${resultsCount === 1 ? "" : "s"} ${trimmedQuery.length > 0
         ? "matching your criteria"
         : "ready to explore"
       }`;
@@ -395,53 +208,12 @@ export function GameClient({
     inputRef.current?.blur();
   };
 
-  const openFilterSheet = (key?: FacetKey) => {
-    if (key) {
-      setPendingScrollKey(key);
-    }
-    setIsFilterSheetOpen(true);
-  };
 
   return (
     <div className="relative min-h-screen bg-surface-sunken text-text-brand">
       <div className="mx-auto flex max-w-7xl flex-wrap gap-6 px-4 py-10 lg:flex-nowrap lg:gap-10">
-        <FilterSidebar
-          filters={filters}
-          facets={facets}
-          filterSearches={filterSearches}
-          setFilterSearches={setFilterSearches}
-          isFilterRailCollapsed={isFilterRailCollapsed}
-          setIsFilterRailCollapsed={setIsFilterRailCollapsed}
-          isFilterSheetOpen={isFilterSheetOpen}
-          closeFilterSheet={closeFilterSheet}
-          resetFilters={resetFilters}
-          updateFilterValue={updateFilterValue}
-          clearFilterGroup={clearFilterGroup}
-          openFilterSheet={openFilterSheet}
-          initialExpandedFilters={initialExpandedFiltersRef.current ?? []}
-        />
-
         <main className="flex min-w-0 flex-1 flex-col gap-8">
           <header className="flex flex-wrap items-center gap-3 rounded-3xl border border-brand-sprout/20 bg-surface-raised p-4 shadow-sm backdrop-blur">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-10 w-10 rounded-full bg-surface-highlight text-text-brand hover:bg-brand-sprout/20"
-              onClick={() => setIsFilterRailCollapsed((prev) => !prev)}
-              aria-label={
-                isFilterRailCollapsed
-                  ? "Expand filter navigation"
-                  : "Collapse filter navigation"
-              }
-            >
-              {isFilterRailCollapsed ? (
-                <PanelLeftOpen className="h-5 w-5" />
-              ) : (
-                <PanelLeftClose className="h-5 w-5" />
-              )}
-            </Button>
-
             <SearchBar
               query={filters.query}
               setQuery={(q) => setFilters(prev => ({ ...prev, query: q, page: DEFAULT_PAGE }))}
@@ -454,20 +226,6 @@ export function GameClient({
               inputRef={inputRef}
             />
 
-            <Button
-              type="button"
-              variant="outline"
-              className="inline-flex flex-shrink-0 items-center gap-2 rounded-full border-brand-sprout/40 bg-white px-4 py-2 text-sm font-semibold text-text-brand hover:bg-brand-sprout/10 focus-visible:ring-brand-marigold"
-              onClick={() => openFilterSheet()}
-            >
-              <Filter className="h-4 w-4 text-brand-sprout" />
-              Filters
-              {hasActiveFilters && (
-                <Badge className="ml-1 rounded-full bg-surface-highlight px-2 py-1 text-[11px] font-semibold text-brand-sprout">
-                  {activeFilters.length}
-                </Badge>
-              )}
-            </Button>
           </header>
 
           <div className="rounded-3xl border border-brand-sprout/20 bg-surface-raised/90 p-6 shadow-sm backdrop-blur">
@@ -483,55 +241,14 @@ export function GameClient({
             <p className="mt-4 max-w-2xl text-sm leading-6 text-text-brand/75">
               Discover activities that spark connection, collaboration, and laughs for every group size.
             </p>
-            <p className="mt-2 text-sm text-text-brand/60">
-              Use the menu button to collapse the filter rail or tap “Filters” to open it as a sheet.
-            </p>
           </div>
 
-          {hasActiveFilters && (
-            <div className="flex flex-wrap items-center gap-2 rounded-3xl border border-brand-sprout/20 bg-surface-raised/90 p-4 shadow-sm backdrop-blur">
-              <span className="text-sm font-medium text-text-brand/80">Active filters:</span>
-              {activeFilters.map(({ key, value }) => {
-                const label = filterMeta[key].label;
-                return (
-                  <Badge
-                    key={`${key}-${value}`}
-                    variant="secondary"
-                    className="flex items-center gap-2 rounded-full bg-surface-highlight px-3 py-1 text-sm font-medium text-text-brand"
-                  >
-                    <span className="font-semibold text-brand-sprout">{label}:</span>
-                    <span>{prettifyFilterValue(value)}</span>
-                    <button
-                      type="button"
-                      className="rounded-full p-0.5 text-brand-sprout transition hover:bg-brand-sprout/20"
-                      onClick={() => updateFilterValue(key, value, false)}
-                    >
-                      <X className="h-3 w-3" />
-                      <span className="sr-only">Remove {prettifyFilterValue(value)}</span>
-                    </button>
-                  </Badge>
-                );
-              })}
-              <Button
-                variant="ghost"
-                size="sm"
-                className="ml-auto h-8 px-3 text-xs font-semibold text-brand-sprout hover:bg-surface-highlight"
-                onClick={resetFilters}
-              >
-                Clear all
-              </Button>
-            </div>
-          )}
 
           <GameGrid
             games={paginatedGames}
             resetFilters={resetFilters}
             bookmarkedIds={bookmarkedIds}
             onToggleBookmark={toggleBookmark}
-            onMetaToggle={updateFilterValue}
-            activeFilters={Object.fromEntries(
-              facetKeys.map((key) => [key, new Set(filters[key])])
-            )}
           />
 
           <PaginationControl

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,43 +1,14 @@
 import { games } from '@/lib/loadGames';
 import { GameClient } from './game-client';
-import { Game } from '@/lib/types';
 import { Suspense } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 
-const getUniqueValues = (games: Game[], key: keyof Game) => {
-  const values = new Set<string>();
-  games.forEach(game => {
-    const value = game[key];
-    if (typeof value === 'string' && value) {
-      values.add(value);
-    } else if (Array.isArray(value)) {
-      value.forEach(v => typeof v === 'string' && v && values.add(v));
-    }
-  });
-  return Array.from(values).sort();
-};
-
-const toRange = (min?: number | null, max?: number | null) => {
-  if (typeof min === 'number' && typeof max === 'number') return `${min}–${max}`;
-  if (typeof min === 'number') return `${min}+`;
-  if (typeof max === 'number') return `Up to ${max}`;
-  return null;
-};
 
 export default function HomePage() {
   const sortedGames = [...games].sort((a, b) =>
     a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
   );
 
-  const facets = {
-    category: getUniqueValues(sortedGames, 'category'),
-    tags: getUniqueValues(sortedGames, 'tags'),
-    prepLevel: getUniqueValues(sortedGames, 'prepLevel'),
-    playersRange: Array.from(new Set(sortedGames.map((g) => toRange(g.playersMin, g.playersMax)).filter(Boolean) as string[])).sort(),
-    ageRange: Array.from(new Set(sortedGames.map((g) => toRange(g.ageMin, g.ageMax)).filter(Boolean) as string[])).sort(),
-    equipmentNeeded: Array.from(new Set(sortedGames.map((g) => (g.equipment ? 'Equipment needed' : null)).filter(Boolean) as string[])).sort(),
-    skillsDeveloped: getUniqueValues(sortedGames, 'skillsDeveloped'),
-  };
 
   return (
     <section className="space-y-12 md:space-y-16">
@@ -72,7 +43,7 @@ export default function HomePage() {
           </div>
         }
       >
-        <GameClient allGames={sortedGames} facets={facets} />
+        <GameClient allGames={sortedGames} />
       </Suspense>
 
       <footer className="rounded-3xl border border-[#1E293B] bg-[#070d1f] px-6 py-10 text-[#94A3B8] md:px-10">

--- a/components/game/game-card.tsx
+++ b/components/game/game-card.tsx
@@ -7,14 +7,11 @@ import { prettifyFilterValue } from "@/lib/utils";
 import { Bookmark, BookmarkCheck } from "lucide-react";
 import Link from "next/link";
 import type { CSSProperties, PointerEvent } from "react";
-import { FacetKey } from "@/lib/constants";
 
 interface GameCardProps {
   game: Game;
   isBookmarked: boolean;
   onToggleBookmark: (id: string) => void;
-  onMetaToggle: (facet: FacetKey, value: string, include: boolean) => void;
-  activeFilters: Partial<Record<FacetKey, Set<string>>>;
 }
 
 const toRange = (min?: number | null, max?: number | null) => {
@@ -24,7 +21,7 @@ const toRange = (min?: number | null, max?: number | null) => {
   return null;
 };
 
-export function GameCard({ game, isBookmarked, onToggleBookmark, onMetaToggle, activeFilters }: GameCardProps) {
+export function GameCard({ game, isBookmarked, onToggleBookmark }: GameCardProps) {
   const card3dStyle = {
     "--rotate-x": "0deg",
     "--rotate-y": "0deg",
@@ -72,14 +69,14 @@ export function GameCard({ game, isBookmarked, onToggleBookmark, onMetaToggle, a
   })();
 
   const metadata = [
-    toRange(game.playersMin, game.playersMax) && { facet: "playersRange" as FacetKey, value: toRange(game.playersMin, game.playersMax) as string, tone: "bg-cyan-500/25" },
-    toRange(game.ageMin, game.ageMax) && { facet: "ageRange" as FacetKey, value: toRange(game.ageMin, game.ageMax) as string, tone: "bg-violet-500/25" },
-    game.prepLevel && { facet: "prepLevel" as FacetKey, value: game.prepLevel, displayValue: prettifyFilterValue(game.prepLevel), tone: "bg-amber-500/25" },
-    game.category && { facet: "category" as FacetKey, value: game.category, displayValue: prettifyFilterValue(game.category), tone: "bg-emerald-500/25" },
-    game.equipment && { facet: "equipmentNeeded" as FacetKey, value: "Equipment needed", displayValue: "Equipment needed", tone: "bg-rose-500/25" },
-    ...(game.skillsDeveloped || []).map((s) => ({ facet: "skillsDeveloped" as FacetKey, value: s, displayValue: prettifyFilterValue(s), tone: "bg-indigo-500/25" })),
-    ...(game.tags || []).map((t) => ({ facet: "tags" as FacetKey, value: t, displayValue: prettifyFilterValue(t), tone: "bg-teal-500/25" })),
-  ].filter(Boolean) as { facet: FacetKey; value: string; displayValue?: string; tone: string }[];
+    toRange(game.playersMin, game.playersMax) && { value: toRange(game.playersMin, game.playersMax) as string, tone: "bg-cyan-500/25" },
+    toRange(game.ageMin, game.ageMax) && { value: toRange(game.ageMin, game.ageMax) as string, tone: "bg-violet-500/25" },
+    game.prepLevel && { value: game.prepLevel, displayValue: prettifyFilterValue(game.prepLevel), tone: "bg-amber-500/25" },
+    game.category && { value: game.category, displayValue: prettifyFilterValue(game.category), tone: "bg-emerald-500/25" },
+    game.equipment && { value: "Equipment needed", displayValue: "Equipment needed", tone: "bg-rose-500/25" },
+    ...(game.skillsDeveloped || []).map((s) => ({ value: s, displayValue: prettifyFilterValue(s), tone: "bg-indigo-500/25" })),
+    ...(game.tags || []).map((t) => ({ value: t, displayValue: prettifyFilterValue(t), tone: "bg-teal-500/25" })),
+  ].filter(Boolean) as { value: string; displayValue?: string; tone: string }[];
 
   return (
     <Card
@@ -124,18 +121,11 @@ export function GameCard({ game, isBookmarked, onToggleBookmark, onMetaToggle, a
         <p className="line-clamp-3 text-sm text-text-brand/75">{game.description || "A playful activity for your next group session."}</p>
         <div className="flex flex-wrap gap-2">
           {metadata.map((item, index) => {
-            const key = `${item.facet}-${item.value}-${index}`;
-            const selected = activeFilters[item.facet]?.has(item.value) ?? false;
+            const key = `${item.value}-${index}`;
             return (
-              <button
-                key={key}
-                type="button"
-                onClick={() => onMetaToggle(item.facet, item.value, !selected)}
-              >
-                <Badge className={`rounded-full px-3 py-1 text-xs font-semibold text-text-brand ${selected ? "bg-brand-sprout text-white" : item.tone}`}>
-                  {item.displayValue ?? item.value}
-                </Badge>
-              </button>
+              <Badge key={key} className={`rounded-full px-3 py-1 text-xs font-semibold text-text-brand ${item.tone}`}>
+                {item.displayValue ?? item.value}
+              </Badge>
             );
           })}
         </div>

--- a/components/game/game-grid.tsx
+++ b/components/game/game-grid.tsx
@@ -10,11 +10,9 @@ interface GameGridProps {
   resetFilters: () => void;
   bookmarkedIds: Set<string>;
   onToggleBookmark: (id: string) => void;
-  onMetaToggle: (facet: FacetKey, value: string, include: boolean) => void;
-  activeFilters: Partial<Record<FacetKey, Set<string>>>;
 }
 
-export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark, onMetaToggle, activeFilters }: GameGridProps) {
+export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark }: GameGridProps) {
   if (games.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-brand-sprout/40 bg-surface-raised p-12 text-center shadow-inner">
@@ -33,11 +31,8 @@ export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark,
           game={game}
           isBookmarked={bookmarkedIds.has(game.id)}
           onToggleBookmark={onToggleBookmark}
-          onMetaToggle={onMetaToggle}
-          activeFilters={activeFilters}
         />
       ))}
     </div>
   );
 }
-import { FacetKey } from "@/lib/constants";


### PR DESCRIPTION
### Motivation
- Reduce complexity by removing facet-based filtering UI and interactions in favor of a simpler search + bookmarks experience.
- Eliminate multi-select facet state, filter rail/sheet behavior, and per-facet query syncing with the URL to streamline the client.

### Description
- Removed facet-related types, props and logic from `GameClient` and `page`, including the `facets` prop, facet parsing/syncing in the URL, and facet selection state and helpers (`updateFilterValue`, `clearFilterGroup`, `filterSearches`, pending scroll, collapse/sheet state, and initial expanded tracking). 
- Removed the `FilterSidebar` component usage and all UI related to collapsing/opening the filter rail or sheet from `game-client.tsx` and the header filter button.
- Simplified filter equality to only compare `query`, `page`, and `bookmarkedOnly`, and preserved text search, Fuse integration, pagination, and bookmark persistence.
- Removed active filter badges and interactivity across `GameCard` and `GameGrid` by dropping meta-toggle callbacks and facet-aware props, and simplified metadata badges to display passive labels only.

### Testing
- Ran a local type check and project build with `npm run type-check` and `npm run build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acb0e85148321af5edf37529038f8)