### PR TITLE
Revamp game metadata into iconized filter buttons

### DIFF
--- a/app/game-client.tsx
+++ b/app/game-client.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { SearchBar } from "@/components/game/search-bar";
 import { GameGrid } from "@/components/game/game-grid";
 import { PaginationControl } from "@/components/game/pagination-control";
+import { getGameMetadataTokens } from "@/lib/game-metadata";
 
 const fuseOptions = {
   keys: ["name", "description", "keywords"],
@@ -26,6 +27,7 @@ type FiltersState = {
   query: string;
   page: number;
   bookmarkedOnly: boolean;
+  metadata: string[];
 };
 
 const DEFAULT_PAGE = 1;
@@ -33,6 +35,7 @@ const createDefaultFilters = (): FiltersState => ({
   query: "",
   page: DEFAULT_PAGE,
   bookmarkedOnly: false,
+  metadata: [],
 });
 
 const parsePageParam = (value: string | null) => {
@@ -53,13 +56,13 @@ const buildFiltersFromParams = (
   next.query = params.get("q") ?? "";
   next.page = parsePageParam(params.get("page"));
   next.bookmarkedOnly = params.get("bookmarked") === "1";
-
+  next.metadata = params.getAll("meta").filter(Boolean);
 
   return next;
 };
 
 const areFiltersEqual = (a: FiltersState, b: FiltersState) =>
-  a.query === b.query && a.page === b.page && a.bookmarkedOnly === b.bookmarkedOnly;
+  a.query === b.query && a.page === b.page && a.bookmarkedOnly === b.bookmarkedOnly && a.metadata.join("|") === b.metadata.join("|");
 
 export function GameClient({
   allGames,
@@ -91,8 +94,10 @@ export function GameClient({
     return searchResults.filter((game) => {
       if (filters.bookmarkedOnly && !bookmarkedIds.has(game.id)) return false;
 
-
-
+      if (filters.metadata.length > 0) {
+        const tokenIds = new Set(getGameMetadataTokens(game).map((token) => token.id));
+        if (!filters.metadata.every((selected) => tokenIds.has(selected))) return false;
+      }
 
       return true;
     });
@@ -111,7 +116,7 @@ export function GameClient({
     if (trimmedQuery) params.set("q", trimmedQuery);
 
     if (filters.bookmarkedOnly) params.set("bookmarked", "1");
-
+    filters.metadata.forEach((metadataId) => params.append("meta", metadataId));
 
     if (currentPage > 1) params.set("page", String(currentPage));
 
@@ -198,6 +203,26 @@ export function GameClient({
     }));
   };
 
+  const availableMetadata = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof getGameMetadataTokens>[number]>();
+    filteredGames.forEach((game) => {
+      getGameMetadataTokens(game).forEach((token) => {
+        if (!map.has(token.id)) map.set(token.id, token);
+      });
+    });
+    return Array.from(map.values()).slice(0, 18);
+  }, [filteredGames]);
+
+  const toggleMetadataFilter = (metadataId: string) => {
+    setFilters((current) => ({
+      ...current,
+      metadata: current.metadata.includes(metadataId)
+        ? current.metadata.filter((id) => id !== metadataId)
+        : [...current.metadata, metadataId],
+      page: DEFAULT_PAGE,
+    }));
+  };
+
   const handleSuggestionSelect = (game: Game) => {
     setFilters((current) => ({
       ...current,
@@ -239,6 +264,23 @@ export function GameClient({
               <button className="rounded-full border-2 border-[#54d8e8] px-6 py-3 text-sm font-semibold text-[#54d8e8] transition hover:bg-[#54d8e8]/10 active:scale-95">
                 Surprise Me
               </button>
+              <div className="flex flex-wrap gap-2">
+                {availableMetadata.map((item) => {
+                  const isActive = filters.metadata.includes(item.id);
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => toggleMetadataFilter(item.id)}
+                      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold transition ${item.tone} ${isActive ? "ring-2 ring-brand-sprout" : "opacity-90 hover:opacity-100"}`}
+                      aria-pressed={isActive}
+                    >
+                      <item.Icon className="h-3.5 w-3.5" />
+                      {item.label}
+                    </button>
+                  );
+                })}
+              </div>
               <div>
                 <h1 className="font-heading text-2xl font-semibold text-text-brand sm:text-3xl">
                   {heading}
@@ -257,6 +299,8 @@ export function GameClient({
             resetFilters={resetFilters}
             bookmarkedIds={bookmarkedIds}
             onToggleBookmark={toggleBookmark}
+            activeMetadataIds={filters.metadata}
+            onMetadataFilter={toggleMetadataFilter}
           />
 
           <PaginationControl

--- a/components/game/game-card.tsx
+++ b/components/game/game-card.tsx
@@ -1,9 +1,8 @@
 import Image from "next/image";
 import { Game } from "@/lib/types";
-import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { prettifyFilterValue } from "@/lib/utils";
+import { getGameMetadataTokens } from "@/lib/game-metadata";
 import { Bookmark, BookmarkCheck } from "lucide-react";
 import Link from "next/link";
 import type { CSSProperties, PointerEvent } from "react";
@@ -12,16 +11,11 @@ interface GameCardProps {
   game: Game;
   isBookmarked: boolean;
   onToggleBookmark: (id: string) => void;
+  activeMetadataIds: string[];
+  onMetadataFilter: (metadataId: string) => void;
 }
 
-const toRange = (min?: number | null, max?: number | null) => {
-  if (typeof min === "number" && typeof max === "number") return `${min}–${max}`;
-  if (typeof min === "number") return `${min}+`;
-  if (typeof max === "number") return `Up to ${max}`;
-  return null;
-};
-
-export function GameCard({ game, isBookmarked, onToggleBookmark }: GameCardProps) {
+export function GameCard({ game, isBookmarked, onToggleBookmark, activeMetadataIds, onMetadataFilter }: GameCardProps) {
   const card3dStyle = {
     "--rotate-x": "0deg",
     "--rotate-y": "0deg",
@@ -68,15 +62,7 @@ export function GameCard({ game, isBookmarked, onToggleBookmark }: GameCardProps
     return `/Itsallfunandgames/${game.image}`;
   })();
 
-  const metadata = [
-    toRange(game.playersMin, game.playersMax) && { value: toRange(game.playersMin, game.playersMax) as string, tone: "bg-cyan-500/25" },
-    toRange(game.ageMin, game.ageMax) && { value: toRange(game.ageMin, game.ageMax) as string, tone: "bg-violet-500/25" },
-    game.prepLevel && { value: game.prepLevel, displayValue: prettifyFilterValue(game.prepLevel), tone: "bg-amber-500/25" },
-    game.category && { value: game.category, displayValue: prettifyFilterValue(game.category), tone: "bg-emerald-500/25" },
-    game.equipment && { value: "Equipment needed", displayValue: "Equipment needed", tone: "bg-rose-500/25" },
-    ...(game.skillsDeveloped || []).map((s) => ({ value: s, displayValue: prettifyFilterValue(s), tone: "bg-indigo-500/25" })),
-    ...(game.tags || []).map((t) => ({ value: t, displayValue: prettifyFilterValue(t), tone: "bg-teal-500/25" })),
-  ].filter(Boolean) as { value: string; displayValue?: string; tone: string }[];
+  const metadata = getGameMetadataTokens(game);
 
   return (
     <Card
@@ -120,12 +106,19 @@ export function GameCard({ game, isBookmarked, onToggleBookmark }: GameCardProps
         </h2>
         <p className="line-clamp-3 text-sm text-text-brand/75">{game.description || "A playful activity for your next group session."}</p>
         <div className="flex flex-wrap gap-2">
-          {metadata.map((item, index) => {
-            const key = `${item.value}-${index}`;
+          {metadata.map((item) => {
+            const isActive = activeMetadataIds.includes(item.id);
             return (
-              <Badge key={key} className={`rounded-full px-3 py-1 text-xs font-semibold text-text-brand ${item.tone}`}>
-                {item.displayValue ?? item.value}
-              </Badge>
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => onMetadataFilter(item.id)}
+                className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold transition ${item.tone} ${isActive ? "ring-2 ring-brand-sprout" : "opacity-90 hover:opacity-100"}`}
+                aria-pressed={isActive}
+              >
+                <item.Icon className="h-3.5 w-3.5" />
+                {item.label}
+              </button>
             );
           })}
         </div>

--- a/components/game/game-grid.tsx
+++ b/components/game/game-grid.tsx
@@ -10,9 +10,11 @@ interface GameGridProps {
   resetFilters: () => void;
   bookmarkedIds: Set<string>;
   onToggleBookmark: (id: string) => void;
+  activeMetadataIds: string[];
+  onMetadataFilter: (metadataId: string) => void;
 }
 
-export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark }: GameGridProps) {
+export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark, activeMetadataIds, onMetadataFilter }: GameGridProps) {
   if (games.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-brand-sprout/40 bg-surface-raised p-12 text-center shadow-inner">
@@ -31,6 +33,8 @@ export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark 
           game={game}
           isBookmarked={bookmarkedIds.has(game.id)}
           onToggleBookmark={onToggleBookmark}
+          activeMetadataIds={activeMetadataIds}
+          onMetadataFilter={onMetadataFilter}
         />
       ))}
     </div>

--- a/lib/game-metadata.ts
+++ b/lib/game-metadata.ts
@@ -1,0 +1,56 @@
+import { Game } from "@/lib/types";
+import { prettifyFilterValue } from "@/lib/utils";
+import { Baby, Sparkles, Tag, Users, Wrench, type LucideIcon } from "lucide-react";
+
+export type MetadataType = "players" | "age" | "prep" | "category" | "equipment" | "skill" | "tag";
+
+export type MetadataToken = {
+  id: string;
+  type: MetadataType;
+  value: string;
+  label: string;
+  Icon: LucideIcon;
+  tone: string;
+};
+
+const toRange = (min?: number | null, max?: number | null) => {
+  if (typeof min === "number" && typeof max === "number") return `${min}–${max}`;
+  if (typeof min === "number") return `${min}+`;
+  if (typeof max === "number") return `Up to ${max}`;
+  return null;
+};
+
+const makeToken = (type: MetadataType, value: string, label: string, Icon: LucideIcon, tone: string): MetadataToken => ({
+  id: `${type}:${value}`,
+  type,
+  value,
+  label,
+  Icon,
+  tone,
+});
+
+export const getGameMetadataTokens = (game: Game): MetadataToken[] => {
+  const tokens: MetadataToken[] = [];
+
+  const players = toRange(game.playersMin, game.playersMax);
+  if (players) tokens.push(makeToken("players", players, players, Users, "bg-cyan-500/25 text-cyan-900 border-cyan-300/50"));
+
+  const ages = toRange(game.ageMin, game.ageMax);
+  if (ages) tokens.push(makeToken("age", ages, ages, Baby, "bg-violet-500/25 text-violet-900 border-violet-300/50"));
+
+  if (game.prepLevel) tokens.push(makeToken("prep", game.prepLevel, prettifyFilterValue(game.prepLevel), Wrench, "bg-amber-500/25 text-amber-900 border-amber-300/50"));
+
+  if (game.category) tokens.push(makeToken("category", game.category, prettifyFilterValue(game.category), Sparkles, "bg-emerald-500/25 text-emerald-900 border-emerald-300/50"));
+
+  if (game.equipment) tokens.push(makeToken("equipment", "equipment-needed", "Equipment needed", Wrench, "bg-rose-500/25 text-rose-900 border-rose-300/50"));
+
+  (game.skillsDeveloped || []).forEach((skill) => {
+    tokens.push(makeToken("skill", skill, prettifyFilterValue(skill), Sparkles, "bg-indigo-500/25 text-indigo-900 border-indigo-300/50"));
+  });
+
+  (game.tags || []).forEach((tag) => {
+    tokens.push(makeToken("tag", tag, prettifyFilterValue(tag), Tag, "bg-teal-500/25 text-teal-900 border-teal-300/50"));
+  });
+
+  return tokens;
+};


### PR DESCRIPTION
### Motivation
- Make game metadata on cards visible as compact icon-prefixed buttons with per-type color so users can quickly identify metadata kinds. 
- Allow tapping those metadata buttons to filter the games list, and expose the same filters in the header alongside the existing actions for discoverability. 
- Ensure a consistent icon, label and color mapping across cards, header controls and the filtering logic.

### Description
- Added a shared helper `getGameMetadataTokens` in `lib/game-metadata.ts` to produce typed metadata tokens (id, type, label, Icon, tone) for a game. 
- Replaced passive metadata badges in `components/game/game-card.tsx` with interactive icon-prefixed button-pills that show active state and call back via `onMetadataFilter`. 
- Plumbed metadata filter state through `components/game/game-grid.tsx` so each `GameCard` receives `activeMetadataIds` and `onMetadataFilter`. 
- Extended `app/game-client.tsx` to hold `metadata` in `FiltersState`, expose header filter buttons (sourced from the currently filtered games), sync selected metadata via `meta=` URL query params, and filter games by requiring selected metadata token ids to be present.

### Testing
- Ran `npm run lint`; it completed with no errors and two pre-existing warnings unrelated to these changes. `npm run lint` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae1c08bc0832184597e054972d860)