### PR TITLE
Add Explore Collection presets and Surprise Me behavior

### DIFF
--- a/app/game-client.tsx
+++ b/app/game-client.tsx
@@ -16,6 +16,7 @@ import { GameGrid } from "@/components/game/game-grid";
 import { PaginationControl } from "@/components/game/pagination-control";
 import { getGameMetadataTokens } from "@/lib/game-metadata";
 import { Bookmark, Compass, Dices } from "lucide-react";
+import { GAME_COLLECTIONS, getMatchingGamesForCollection } from "@/lib/collections";
 
 const fuseOptions = {
   keys: ["name", "description", "keywords"],
@@ -32,117 +33,76 @@ type FiltersState = {
 };
 
 const DEFAULT_PAGE = 1;
-const createDefaultFilters = (): FiltersState => ({
-  query: "",
-  page: DEFAULT_PAGE,
-  bookmarkedOnly: false,
-  metadata: [],
-});
-
+const createDefaultFilters = (): FiltersState => ({ query: "", page: DEFAULT_PAGE, bookmarkedOnly: false, metadata: [] });
 const parsePageParam = (value: string | null) => {
-  if (!value) {
-    return DEFAULT_PAGE;
-  }
+  if (!value) return DEFAULT_PAGE;
   const parsed = Number.parseInt(value, 10);
-  if (Number.isNaN(parsed) || parsed < DEFAULT_PAGE) {
-    return DEFAULT_PAGE;
-  }
+  if (Number.isNaN(parsed) || parsed < DEFAULT_PAGE) return DEFAULT_PAGE;
   return parsed;
 };
-
-const buildFiltersFromParams = (
-  params: ReadonlyURLSearchParams
-): FiltersState => {
+const buildFiltersFromParams = (params: ReadonlyURLSearchParams): FiltersState => {
   const next = createDefaultFilters();
   next.query = params.get("q") ?? "";
   next.page = parsePageParam(params.get("page"));
   next.bookmarkedOnly = params.get("bookmarked") === "1";
   next.metadata = params.getAll("meta").filter(Boolean);
-
   return next;
 };
+const areFiltersEqual = (a: FiltersState, b: FiltersState) => a.query === b.query && a.page === b.page && a.bookmarkedOnly === b.bookmarkedOnly && a.metadata.join("|") === b.metadata.join("|");
 
-const areFiltersEqual = (a: FiltersState, b: FiltersState) =>
-  a.query === b.query && a.page === b.page && a.bookmarkedOnly === b.bookmarkedOnly && a.metadata.join("|") === b.metadata.join("|");
-
-export function GameClient({
-  allGames,
-}: {
-  allGames: Game[];
-}) {
+export function GameClient({ allGames }: { allGames: Game[] }) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const perPage = 12;
-
   const fuse = useMemo(() => new Fuse(allGames, fuseOptions), [allGames]);
 
-  const [filters, setFilters] = useState<FiltersState>(() =>
-    buildFiltersFromParams(searchParams)
-  );
+  const [filters, setFilters] = useState<FiltersState>(() => buildFiltersFromParams(searchParams));
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-
   const [debouncedQuery] = useDebounce(filters.query, 300);
   const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set());
+  const [isCollectionsOpen, setIsCollectionsOpen] = useState(false);
+  const [selectedCollectionId, setSelectedCollectionId] = useState<string | null>(null);
+  const [randomGameId, setRandomGameId] = useState<string | null>(null);
+  const [highlightedGameId, setHighlightedGameId] = useState<string | null>(null);
+  const lastRandomGameIdRef = useRef<string | null>(null);
 
   const filteredGames = useMemo(() => {
     const trimmedQuery = debouncedQuery.trim();
-    const searchResults = trimmedQuery
-      ? fuse.search(trimmedQuery).map((res) => res.item)
-      : allGames;
-
+    const searchResults = trimmedQuery ? fuse.search(trimmedQuery).map((res) => res.item) : allGames;
     return searchResults.filter((game) => {
       if (filters.bookmarkedOnly && !bookmarkedIds.has(game.id)) return false;
-
       if (filters.metadata.length > 0) {
         const tokenIds = new Set(getGameMetadataTokens(game).map((token) => token.id));
         if (!filters.metadata.every((selected) => tokenIds.has(selected))) return false;
       }
-
       return true;
     });
   }, [allGames, debouncedQuery, filters, fuse, bookmarkedIds]);
 
   const totalPages = Math.ceil(filteredGames.length / perPage);
   const currentPage = Math.min(filters.page, totalPages || 1);
-  const paginatedGames = filteredGames.slice(
-    (currentPage - 1) * perPage,
-    currentPage * perPage
-  );
+  const paginatedGames = filteredGames.slice((currentPage - 1) * perPage, currentPage * perPage);
 
   useEffect(() => {
     const params = new URLSearchParams();
     const trimmedQuery = filters.query.trim();
     if (trimmedQuery) params.set("q", trimmedQuery);
-
     if (filters.bookmarkedOnly) params.set("bookmarked", "1");
     filters.metadata.forEach((metadataId) => params.append("meta", metadataId));
-
     if (currentPage > 1) params.set("page", String(currentPage));
-
     const search = params.toString();
     const currentSearch = searchParams.toString();
-
-    if (search === currentSearch) {
-      return;
-    }
-
+    if (search === currentSearch) return;
     const next = search ? `${pathname}?${search}` : pathname;
     router.replace(next);
   }, [filters, currentPage, pathname, router, searchParams]);
 
   useEffect(() => {
     const nextFilters = buildFiltersFromParams(searchParams);
-    setFilters((current) =>
-      areFiltersEqual(current, nextFilters) ? current : nextFilters
-    );
+    setFilters((current) => (areFiltersEqual(current, nextFilters) ? current : nextFilters));
   }, [searchParams]);
-
-
-
-
-
 
   useEffect(() => {
     const stored = window.localStorage.getItem("iafg-bookmarks");
@@ -152,6 +112,15 @@ export function GameClient({
       setBookmarkedIds(new Set(parsed));
     } catch {}
   }, []);
+
+  useEffect(() => {
+    if (!isCollectionsOpen) return;
+    const onEsc = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsCollectionsOpen(false);
+    };
+    window.addEventListener("keydown", onEsc);
+    return () => window.removeEventListener("keydown", onEsc);
+  }, [isCollectionsOpen]);
 
   const toggleBookmark = (id: string) => {
     setBookmarkedIds((prev) => {
@@ -163,172 +132,170 @@ export function GameClient({
   };
 
   const resetFilters = () => {
+    setSelectedCollectionId(null);
     setFilters(createDefaultFilters());
   };
 
-  const handlePageChange = (page: number) => {
-    setFilters((f) => ({ ...f, page: Math.max(page, DEFAULT_PAGE) }));
-  };
+  const handlePageChange = (page: number) => setFilters((f) => ({ ...f, page: Math.max(page, DEFAULT_PAGE) }));
 
   const suggestions = useMemo(() => {
     const trimmed = filters.query.trim();
-    if (trimmed.length < 2) {
-      return [] as Game[];
-    }
+    if (trimmed.length < 2) return [] as Game[];
     return fuse.search(trimmed).slice(0, 5).map((result) => result.item);
   }, [filters.query, fuse]);
 
   const showSuggestions = isSearchFocused && suggestions.length > 0;
-
-
   const trimmedQuery = filters.query.trim();
   const resultsCount = filteredGames.length;
-  const heading =
-    trimmedQuery.length > 0
-      ? `Results for “${trimmedQuery}` + "”"
-      : "Showing all games";
-  const resultsSummary =
-    resultsCount === 0
-      ? "No games match your current filters."
-      : `${resultsCount} game${resultsCount === 1 ? "" : "s"} ${trimmedQuery.length > 0
-        ? "matching your criteria"
-        : "ready to explore"
-      }`;
+  const heading = trimmedQuery.length > 0 ? `Results for “${trimmedQuery}”` : "Showing all games";
+  const resultsSummary = resultsCount === 0 ? "No games match your current filters." : `${resultsCount} game${resultsCount === 1 ? "" : "s"} ${trimmedQuery.length > 0 ? "matching your criteria" : "ready to explore"}`;
+
+  const collectionCounts = useMemo(
+    () => Object.fromEntries(GAME_COLLECTIONS.map((collection) => [collection.id, allGames.filter(collection.matches).length])),
+    [allGames]
+  );
+
+  const applyCollection = (collectionId: string) => {
+    const matchedGames = getMatchingGamesForCollection(allGames, collectionId);
+    const matchedIds = new Set(matchedGames.map((game) => game.id));
+    const metadataToKeep = Array.from(new Set(matchedGames.flatMap((game) => getGameMetadataTokens(game).map((token) => token.id))));
+    setSelectedCollectionId(collectionId);
+    setFilters((current) => ({ ...current, query: "", bookmarkedOnly: false, metadata: current.metadata.filter((id) => metadataToKeep.includes(id)), page: DEFAULT_PAGE }));
+    if (matchedIds.size === 0) return;
+    setFilters((current) => ({ ...current, page: DEFAULT_PAGE }));
+    setRandomGameId(null);
+    setHighlightedGameId(null);
+  };
+
+  const clearCollection = () => {
+    setSelectedCollectionId(null);
+    setFilters(createDefaultFilters());
+  };
+
+  const visibleGames = useMemo(() => {
+    if (!selectedCollectionId) return filteredGames;
+    const ids = new Set(getMatchingGamesForCollection(allGames, selectedCollectionId).map((game) => game.id));
+    return filteredGames.filter((game) => ids.has(game.id));
+  }, [allGames, filteredGames, selectedCollectionId]);
+
+  const currentRandomGame = useMemo(() => visibleGames.find((game) => game.id === randomGameId) ?? null, [visibleGames, randomGameId]);
+
+  const pickSurpriseGame = () => {
+    if (visibleGames.length === 0) {
+      setRandomGameId(null);
+      return;
+    }
+    const eligible = visibleGames.filter((game) => game.id !== lastRandomGameIdRef.current);
+    const pool = eligible.length > 0 ? eligible : visibleGames;
+    const picked = pool[Math.floor(Math.random() * pool.length)];
+    lastRandomGameIdRef.current = picked.id;
+    setRandomGameId(picked.id);
+    setHighlightedGameId(picked.id);
+    setTimeout(() => setHighlightedGameId((current) => (current === picked.id ? null : current)), 2200);
+    document.getElementById(`game-card-${picked.id}`)?.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
 
   const handleSearchSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setFilters((current) => ({
-      ...current,
-      query: current.query.trim(),
-      page: DEFAULT_PAGE,
-    }));
+    setFilters((current) => ({ ...current, query: current.query.trim(), page: DEFAULT_PAGE }));
   };
 
   const availableMetadata = useMemo(() => {
+    const sourceGames = selectedCollectionId ? visibleGames : filteredGames;
     const map = new Map<string, ReturnType<typeof getGameMetadataTokens>[number]>();
-    filteredGames.forEach((game) => {
+    sourceGames.forEach((game) => {
       getGameMetadataTokens(game).forEach((token) => {
         if (!map.has(token.id)) map.set(token.id, token);
       });
     });
     return Array.from(map.values()).slice(0, 18);
-  }, [filteredGames]);
+  }, [filteredGames, selectedCollectionId, visibleGames]);
 
-  const toggleMetadataFilter = (metadataId: string) => {
-    setFilters((current) => ({
-      ...current,
-      metadata: current.metadata.includes(metadataId)
-        ? current.metadata.filter((id) => id !== metadataId)
-        : [...current.metadata, metadataId],
-      page: DEFAULT_PAGE,
-    }));
-  };
+  const toggleMetadataFilter = (metadataId: string) => setFilters((current) => ({ ...current, metadata: current.metadata.includes(metadataId) ? current.metadata.filter((id) => id !== metadataId) : [...current.metadata, metadataId], page: DEFAULT_PAGE }));
 
   const handleSuggestionSelect = (game: Game) => {
-    setFilters((current) => ({
-      ...current,
-      query: game.name,
-      page: DEFAULT_PAGE,
-    }));
+    setFilters((current) => ({ ...current, query: game.name, page: DEFAULT_PAGE }));
     setIsSearchFocused(false);
     inputRef.current?.blur();
   };
-
 
   return (
     <div className="relative min-h-screen bg-surface-sunken text-text-brand">
       <div className="mx-auto flex max-w-7xl flex-wrap gap-6 px-4 py-10 lg:flex-nowrap lg:gap-10">
         <main className="flex min-w-0 flex-1 flex-col gap-8">
           <header className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-[0_20px_45px_rgba(0,0,0,0.2)] backdrop-blur-xl sm:p-5">
-            <SearchBar
-              query={filters.query}
-              setQuery={(q) => setFilters(prev => ({ ...prev, query: q, page: DEFAULT_PAGE }))}
-              isSearchFocused={isSearchFocused}
-              setIsSearchFocused={setIsSearchFocused}
-              showSuggestions={showSuggestions}
-              suggestions={suggestions}
-              handleSearchSubmit={handleSearchSubmit}
-              handleSuggestionSelect={handleSuggestionSelect}
-              inputRef={inputRef}
-            />
-
+            <SearchBar query={filters.query} setQuery={(q) => setFilters(prev => ({ ...prev, query: q, page: DEFAULT_PAGE }))} isSearchFocused={isSearchFocused} setIsSearchFocused={setIsSearchFocused} showSuggestions={showSuggestions} suggestions={suggestions} handleSearchSubmit={handleSearchSubmit} handleSuggestionSelect={handleSuggestionSelect} inputRef={inputRef} />
           </header>
 
           <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-[0_20px_45px_rgba(0,0,0,0.2)] backdrop-blur-xl sm:p-6">
             <div className="space-y-5">
               <div className="flex flex-wrap items-center gap-3">
-                <Button
-                  type="button"
-                  variant={filters.bookmarkedOnly ? "default" : "outline"}
-                  className="h-11 gap-2 rounded-xl border-white/20 bg-brand-marigold px-4 text-sm font-semibold text-brand-ink hover:bg-brand-marigold-dark"
-                  onClick={() => setFilters((p) => ({ ...p, bookmarkedOnly: !p.bookmarkedOnly, page: DEFAULT_PAGE }))}
-                >
-                  <Bookmark className="h-4 w-4" />
-                  Bookmark only
+                <Button type="button" variant={filters.bookmarkedOnly ? "default" : "outline"} className="h-11 gap-2 rounded-xl border-white/20 bg-brand-marigold px-4 text-sm font-semibold text-brand-ink hover:bg-brand-marigold-dark" onClick={() => setFilters((p) => ({ ...p, bookmarkedOnly: !p.bookmarkedOnly, page: DEFAULT_PAGE }))}>
+                  <Bookmark className="h-4 w-4" /> Bookmark only
                 </Button>
-                <button
-                  type="button"
-                  className="inline-flex h-11 items-center gap-2 rounded-xl border border-fuchsia-300/40 bg-fuchsia-400/20 px-4 text-sm font-semibold text-fuchsia-100 transition hover:bg-fuchsia-400/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-300/70"
-                >
-                  <Compass className="h-4 w-4" />
-                  Explore Collection
+                <button type="button" aria-label="Explore curated game collections" aria-expanded={isCollectionsOpen} onClick={() => setIsCollectionsOpen((open) => !open)} className="inline-flex h-11 items-center gap-2 rounded-xl border border-fuchsia-300/40 bg-fuchsia-400/20 px-4 text-sm font-semibold text-fuchsia-100 transition hover:bg-fuchsia-400/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-300/70">
+                  <Compass className="h-4 w-4" /> Explore Collection
                 </button>
-                <button
-                  type="button"
-                  className="inline-flex h-11 items-center gap-2 rounded-xl border border-cyan-300/40 bg-cyan-400/15 px-4 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-400/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70"
-                >
-                  <Dices className="h-4 w-4" />
-                  Surprise Me
+                <button type="button" aria-label="Pick a random game" onClick={pickSurpriseGame} className="inline-flex h-11 items-center gap-2 rounded-xl border border-cyan-300/40 bg-cyan-400/15 px-4 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-400/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70">
+                  <Dices className="h-4 w-4" /> Surprise Me
                 </button>
+                {selectedCollectionId && <Button type="button" variant="ghost" className="h-11 rounded-xl text-sm" onClick={clearCollection}>Clear collection</Button>}
               </div>
+
+              {isCollectionsOpen && (
+                <section className="rounded-2xl border border-white/15 bg-black/25 p-4" aria-label="Curated collections">
+                  <div className="mb-3 flex items-center justify-between">
+                    <p className="text-sm font-semibold text-text-brand/90">Browse by collection</p>
+                    <button type="button" onClick={() => setIsCollectionsOpen(false)} className="text-xs text-text-brand/70 hover:text-text-brand">Close</button>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                    {GAME_COLLECTIONS.map((collection) => {
+                      const active = selectedCollectionId === collection.id;
+                      return (
+                        <button key={collection.id} type="button" onClick={() => applyCollection(collection.id)} className={`rounded-2xl border p-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-300/70 ${active ? "border-fuchsia-200/70 bg-fuchsia-400/30" : "border-white/15 bg-white/5 hover:bg-white/10"}`}>
+                          <p className="text-sm font-semibold text-text-brand">{collection.title}</p>
+                          <p className="mt-1 text-xs text-text-brand/75">{collection.description}</p>
+                          <p className="mt-2 text-xs text-text-brand/65">{collectionCounts[collection.id] ?? 0} games</p>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </section>
+              )}
+
+              {randomGameId && (
+                <section className="rounded-2xl border border-cyan-300/40 bg-cyan-400/15 p-4" aria-live="polite">
+                  {currentRandomGame ? (
+                    <>
+                      <p className="text-sm font-semibold text-cyan-100">🎲 Surprise pick: {currentRandomGame.name}</p>
+                      <p className="mt-1 text-sm text-cyan-50/90">{currentRandomGame.description || "A playful activity for your group."}</p>
+                      <p className="mt-2 text-xs text-cyan-100/80">Ages: {currentRandomGame.ageMin ?? "?"}–{currentRandomGame.ageMax ?? "?"} • Players: {currentRandomGame.playersMin ?? "?"}{currentRandomGame.playersMax ? `-${currentRandomGame.playersMax}` : "+"} • Prep: {currentRandomGame.prepLevel ?? "Unknown"}</p>
+                      <p className="mt-1 text-xs text-cyan-100/80">{selectedCollectionId || trimmedQuery || filters.metadata.length > 0 || filters.bookmarkedOnly ? "Picked from your current filters." : "Picked from the full collection."}</p>
+                      <Button type="button" size="sm" onClick={pickSurpriseGame} className="mt-3 rounded-full bg-cyan-200 text-cyan-950 hover:bg-cyan-100">Try another</Button>
+                    </>
+                  ) : (
+                    <p className="text-sm text-cyan-50">No matching games right now. Try clearing some filters first.</p>
+                  )}
+                </section>
+              )}
+
               <div className="flex flex-wrap gap-2.5">
                 {availableMetadata.map((item) => {
                   const isActive = filters.metadata.includes(item.id);
                   return (
-                    <button
-                      key={item.id}
-                      type="button"
-                      onClick={() => toggleMetadataFilter(item.id)}
-                      className={`inline-flex h-9 items-center gap-2 rounded-full border px-3.5 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-marigold/70 ${
-                        isActive
-                          ? "border-brand-sprout/70 bg-brand-sprout/20 text-text-brand shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]"
-                          : "border-white/20 bg-black/25 text-text-brand/85 hover:border-brand-sprout/45 hover:bg-black/35"
-                      }`}
-                      aria-pressed={isActive}
-                    >
-                      <item.Icon className="h-3.5 w-3.5 shrink-0 text-text-brand/80" />
-                      {item.label}
+                    <button key={item.id} type="button" onClick={() => toggleMetadataFilter(item.id)} className={`inline-flex h-9 items-center gap-2 rounded-full border px-3.5 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-marigold/70 ${isActive ? "border-brand-sprout/70 bg-brand-sprout/20 text-text-brand shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]" : "border-white/20 bg-black/25 text-text-brand/85 hover:border-brand-sprout/45 hover:bg-black/35"}`} aria-pressed={isActive}>
+                      <item.Icon className="h-3.5 w-3.5 shrink-0 text-text-brand/80" /> {item.label}
                     </button>
                   );
                 })}
               </div>
-              <div className="pt-1">
-                <h1 className="font-heading text-2xl font-semibold text-text-brand sm:text-3xl">
-                  {heading}
-                </h1>
-                <p className="mt-2 text-sm text-text-brand/70">{resultsSummary}</p>
-              </div>
+              <div className="pt-1"><h1 className="font-heading text-2xl font-semibold text-text-brand sm:text-3xl">{heading}</h1><p className="mt-2 text-sm text-text-brand/70">{resultsSummary}</p></div>
             </div>
-            <p className="mt-4 max-w-2xl text-sm leading-6 text-text-brand/75">
-              Discover activities that spark connection, collaboration, and laughs for every group size.
-            </p>
+            <p className="mt-4 max-w-2xl text-sm leading-6 text-text-brand/75">Discover activities that spark connection, collaboration, and laughs for every group size.</p>
           </div>
 
-
-          <GameGrid
-            games={paginatedGames}
-            resetFilters={resetFilters}
-            bookmarkedIds={bookmarkedIds}
-            onToggleBookmark={toggleBookmark}
-            activeMetadataIds={filters.metadata}
-            onMetadataFilter={toggleMetadataFilter}
-          />
-
-          <PaginationControl
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPageChange={handlePageChange}
-          />
+          <GameGrid games={selectedCollectionId ? visibleGames.slice((currentPage - 1) * perPage, currentPage * perPage) : paginatedGames} resetFilters={resetFilters} bookmarkedIds={bookmarkedIds} onToggleBookmark={toggleBookmark} activeMetadataIds={filters.metadata} onMetadataFilter={toggleMetadataFilter} highlightedGameId={highlightedGameId} />
+          <PaginationControl currentPage={currentPage} totalPages={Math.ceil((selectedCollectionId ? visibleGames.length : filteredGames.length) / perPage)} onPageChange={handlePageChange} />
         </main>
       </div>
     </div>

--- a/components/game/game-card.tsx
+++ b/components/game/game-card.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import type { CSSProperties, PointerEvent } from "react";
 
 interface GameCardProps {
+  isHighlighted?: boolean;
   game: Game;
   isBookmarked: boolean;
   onToggleBookmark: (id: string) => void;
@@ -15,7 +16,7 @@ interface GameCardProps {
   onMetadataFilter: (metadataId: string) => void;
 }
 
-export function GameCard({ game, isBookmarked, onToggleBookmark, activeMetadataIds, onMetadataFilter }: GameCardProps) {
+export function GameCard({ game, isBookmarked, onToggleBookmark, activeMetadataIds, onMetadataFilter, isHighlighted }: GameCardProps) {
   const card3dStyle = {
     "--rotate-x": "0deg",
     "--rotate-y": "0deg",
@@ -74,7 +75,8 @@ export function GameCard({ game, isBookmarked, onToggleBookmark, activeMetadataI
           resetPointerState(event.currentTarget);
         }
       }}
-      className="game-card-3d w-full max-w-[400px] overflow-hidden rounded-3xl border border-brand-sprout/25 bg-surface-raised"
+      id={`game-card-${game.id}`}
+      className={`game-card-3d w-full max-w-[400px] overflow-hidden rounded-3xl border bg-surface-raised transition-shadow ${isHighlighted ? "border-cyan-300 shadow-[0_0_0_2px_rgba(103,232,249,0.7),0_25px_40px_rgba(0,0,0,0.35)]" : "border-brand-sprout/25"}` }
     >
       <div className="relative aspect-[16/9] w-full overflow-hidden bg-gradient-to-br from-brand-sprout/15 via-brand-marigold/15 to-brand-coral/20">
         {imageSrc ? (

--- a/components/game/game-grid.tsx
+++ b/components/game/game-grid.tsx
@@ -6,6 +6,7 @@ import styles from "@/app/game-client.module.css";
 import { cn } from "@/lib/utils";
 
 interface GameGridProps {
+  highlightedGameId?: string | null;
   games: Game[];
   resetFilters: () => void;
   bookmarkedIds: Set<string>;
@@ -14,7 +15,7 @@ interface GameGridProps {
   onMetadataFilter: (metadataId: string) => void;
 }
 
-export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark, activeMetadataIds, onMetadataFilter }: GameGridProps) {
+export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark, activeMetadataIds, onMetadataFilter, highlightedGameId }: GameGridProps) {
   if (games.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-brand-sprout/40 bg-surface-raised p-12 text-center shadow-inner">
@@ -35,6 +36,7 @@ export function GameGrid({ games, resetFilters, bookmarkedIds, onToggleBookmark,
           onToggleBookmark={onToggleBookmark}
           activeMetadataIds={activeMetadataIds}
           onMetadataFilter={onMetadataFilter}
+          isHighlighted={highlightedGameId === game.id}
         />
       ))}
     </div>

--- a/lib/collections.ts
+++ b/lib/collections.ts
@@ -1,0 +1,98 @@
+import { Game } from "@/lib/types";
+
+export type GameCollection = {
+  id: string;
+  title: string;
+  description: string;
+  matches: (game: Game) => boolean;
+};
+
+const includesAny = (value: string | undefined | null, terms: string[]) => {
+  const text = (value ?? "").toLowerCase();
+  return terms.some((term) => text.includes(term));
+};
+
+const listIncludesAny = (list: string[] | undefined, terms: string[]) =>
+  (list ?? []).some((item) => includesAny(item, terms));
+
+const parseLargeGroupHint = (value: string | undefined | null) => {
+  if (!value) return false;
+  if (value.includes("+")) {
+    const numeric = Number.parseInt(value, 10);
+    return Number.isFinite(numeric) && numeric >= 8;
+  }
+  return includesAny(value, ["large", "whole class", "big group", "group"]);
+};
+
+const noEquipmentSignals = ["none", "no equipment", "nothing", "n/a", "na", "not required"];
+
+export const GAME_COLLECTIONS: GameCollection[] = [
+  {
+    id: "quick-wins",
+    title: "Quick wins",
+    description: "Low-prep activities that are easy to start.",
+    matches: (game) => {
+      const prep = game.prepLevel?.toLowerCase() ?? "";
+      const easyPrep = ["little", "low", "none", "minimal", "unknown"].some((key) => prep.includes(key));
+      const simpleEquipment = !game.equipment || includesAny(game.equipment, noEquipmentSignals);
+      return easyPrep || simpleEquipment;
+    },
+  },
+  {
+    id: "moving",
+    title: "Get them moving",
+    description: "Physical activity and movement-focused games.",
+    matches: (game) =>
+      includesAny(game.category, ["physical", "active", "outdoor", "wide"]) ||
+      listIncludesAny(game.tags, ["run", "movement", "tag", "active", "wide"]) ||
+      listIncludesAny(game.skillsDeveloped, ["agility", "coordination", "fitness"]),
+  },
+  {
+    id: "calm-room",
+    title: "Calm the room",
+    description: "Quieter, lower-energy games for focus.",
+    matches: (game) =>
+      listIncludesAny(game.tags, ["listening", "focus", "calm", "quiet", "classroom"]) ||
+      listIncludesAny(game.skillsDeveloped, ["focus", "listening", "self regulation", "patience"]) ||
+      includesAny(game.description, ["quiet", "calm", "listen", "focus"]),
+  },
+  {
+    id: "no-equipment",
+    title: "No equipment needed",
+    description: "Games that can run with little or no gear.",
+    matches: (game) => !game.equipment || includesAny(game.equipment, noEquipmentSignals),
+  },
+  {
+    id: "big-groups",
+    title: "Best for big groups",
+    description: "Suitable for larger groups and whole-class play.",
+    matches: (game) =>
+      game.playersMax === null ||
+      (typeof game.playersMax === "number" && game.playersMax >= 10) ||
+      parseLargeGroupHint(game.recommendedPlayersText),
+  },
+  {
+    id: "listening-reaction",
+    title: "Listening and reaction games",
+    description: "Attention, reaction, and fast-response activities.",
+    matches: (game) =>
+      listIncludesAny(game.skillsDeveloped, ["listening", "reaction", "coordination", "spatial awareness", "attention"]) ||
+      listIncludesAny(game.tags, ["listening", "reaction", "reflex", "quick", "signal"]) ||
+      includesAny(game.description, ["listen", "signal", "react", "response"]),
+  },
+  {
+    id: "teamwork",
+    title: "Teamwork games",
+    description: "Games that build collaboration and communication.",
+    matches: (game) =>
+      listIncludesAny(game.skillsDeveloped, ["teamwork", "collaboration", "communication"]) ||
+      listIncludesAny(game.tags, ["team", "cooperative", "collaboration"]) ||
+      includesAny(game.description, ["team", "together", "collaborate"]),
+  },
+];
+
+export const getMatchingGamesForCollection = (games: Game[], collectionId: string) => {
+  const collection = GAME_COLLECTIONS.find((item) => item.id === collectionId);
+  if (!collection) return [];
+  return games.filter(collection.matches);
+};


### PR DESCRIPTION
### Motivation
- Provide curated, metadata-driven ways for users to browse the game library without knowing exact search terms. 
- Give users a quick, fun way to discover a single game from their current view with a non-repeating random picker.

### Description
- Added a reusable collection system in `lib/collections.ts` with `GAME_COLLECTIONS` and `getMatchingGamesForCollection` so collections are defined by metadata-driven matchers rather than hard-coded IDs. 
- Implemented the `Explore Collection` UI and behavior in `app/game-client.tsx`, including a toggleable panel, per-collection result counts, visual highlight for the selected collection, `Clear collection` action, and Escape-key close handling. 
- Implemented `Surprise Me` behavior in `app/game-client.tsx` that picks a random game from the currently visible/filtered set, avoids immediately repeating the last pick when possible, shows a small featured result with a `Try another` action, scrolls to the selected card, and briefly highlights it. 
- Integrated highlight/scroll behavior by adding `highlightedGameId` support to `components/game/game-grid.tsx` and `components/game/game-card.tsx` and by reusing `getGameMetadataTokens` for collection-aware metadata filtering and available metadata lists.

### Testing
- Ran `npm run lint` which completed successfully with two pre-existing warnings in unrelated files. 
- Ran `npm run build` which completed a successful production build and static page generation with the same non-blocking warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2c9a7d40832185f6759a971c1a92)